### PR TITLE
[1.16.x] Support serviceAccountName configuration overwrite (recovery)

### DIFF
--- a/api/v1/kubegres_types.go
+++ b/api/v1/kubegres_types.go
@@ -66,20 +66,21 @@ type Probe struct {
 }
 
 type KubegresSpec struct {
-	Replicas         *int32                    `json:"replicas,omitempty"`
-	Image            string                    `json:"image,omitempty"`
-	Port             int32                     `json:"port,omitempty"`
-	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	CustomConfig     string                    `json:"customConfig,omitempty"`
-	Database         KubegresDatabase          `json:"database,omitempty"`
-	Failover         KubegresFailover          `json:"failover,omitempty"`
-	Backup           KubegresBackUp            `json:"backup,omitempty"`
-	Env              []v1.EnvVar               `json:"env,omitempty"`
-	Scheduler        KubegresScheduler         `json:"scheduler,omitempty"`
-	Resources        v1.ResourceRequirements   `json:"resources,omitempty"`
-	Volume           Volume                    `json:"volume,omitempty"`
-	SecurityContext  *v1.PodSecurityContext    `json:"securityContext,omitempty"`
-	Probe            Probe                     `json:"probe,omitempty"`
+	Replicas           *int32                    `json:"replicas,omitempty"`
+	Image              string                    `json:"image,omitempty"`
+	Port               int32                     `json:"port,omitempty"`
+	ImagePullSecrets   []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	CustomConfig       string                    `json:"customConfig,omitempty"`
+	Database           KubegresDatabase          `json:"database,omitempty"`
+	Failover           KubegresFailover          `json:"failover,omitempty"`
+	Backup             KubegresBackUp            `json:"backup,omitempty"`
+	Env                []v1.EnvVar               `json:"env,omitempty"`
+	Scheduler          KubegresScheduler         `json:"scheduler,omitempty"`
+	Resources          v1.ResourceRequirements   `json:"resources,omitempty"`
+	Volume             Volume                    `json:"volume,omitempty"`
+	SecurityContext    *v1.PodSecurityContext    `json:"securityContext,omitempty"`
+	Probe              Probe                     `json:"probe,omitempty"`
+	ServiceAccountName string                    `json:"serviceAccountName,omitempty"`
 }
 
 // ----------------------- STATUS -----------------------------------------

--- a/config/crd/bases/kubegres.reactive-tech.io_kubegres.yaml
+++ b/config/crd/bases/kubegres.reactive-tech.io_kubegres.yaml
@@ -1595,6 +1595,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountName:
+                type: string
               volume:
                 properties:
                   volumeClaimTemplates:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: reactivetechio/kubegres
-  newTag: "1.16"
+  newName: tetrate/kubegres
+  newTag: v1.16.0-tetrate-v5

--- a/controllers/ctx/KubegresContext.go
+++ b/controllers/ctx/KubegresContext.go
@@ -22,12 +22,13 @@ package ctx
 
 import (
 	"context"
+	"strconv"
+	"strings"
+
 	"reactive-tech.io/kubegres/api/v1"
 	"reactive-tech.io/kubegres/controllers/ctx/log"
 	"reactive-tech.io/kubegres/controllers/ctx/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
 )
 
 type KubegresContext struct {
@@ -48,6 +49,7 @@ const (
 	BaseConfigMapName                      = "base-kubegres-config"
 	CronJobNamePrefix                      = "backup-"
 	DefaultContainerPortNumber             = 5432
+	DefaultPodServiceAccountName           = "default"
 	DefaultDatabaseVolumeMount             = "/var/lib/postgresql/data"
 	DefaultDatabaseFolder                  = "pgdata"
 	EnvVarNamePgData                       = "PGDATA"

--- a/controllers/ctx/resources/ResourcesContext.go
+++ b/controllers/ctx/resources/ResourcesContext.go
@@ -166,6 +166,7 @@ func addStatefulSetSpecEnforcers(rc *ResourcesContext) {
 	securityContextSpecEnforcer := statefulset_spec.CreateSecurityContextSpecEnforcer(rc.KubegresContext)
 	livenessProbeSpecEnforcer := statefulset_spec.CreateLivenessProbeSpecEnforcer(rc.KubegresContext)
 	readinessProbeSpecEnforcer := statefulset_spec.CreateReadinessProbeSpecEnforcer(rc.KubegresContext)
+	serviAccountNameSpecEnforcer := statefulset_spec.CreateServiceAccountNameSpecEnforcer(rc.KubegresContext)
 
 	rc.StatefulSetsSpecsEnforcer = statefulset_spec.CreateStatefulSetsSpecsEnforcer(rc.KubegresContext)
 	rc.StatefulSetsSpecsEnforcer.AddSpecEnforcer(&imageSpecEnforcer)
@@ -179,6 +180,7 @@ func addStatefulSetSpecEnforcers(rc *ResourcesContext) {
 	rc.StatefulSetsSpecsEnforcer.AddSpecEnforcer(&securityContextSpecEnforcer)
 	rc.StatefulSetsSpecsEnforcer.AddSpecEnforcer(&livenessProbeSpecEnforcer)
 	rc.StatefulSetsSpecsEnforcer.AddSpecEnforcer(&readinessProbeSpecEnforcer)
+	rc.StatefulSetsSpecsEnforcer.AddSpecEnforcer(&serviAccountNameSpecEnforcer)
 
 	rc.AllStatefulSetsSpecEnforcer = statefulset_spec.CreateAllStatefulSetsSpecEnforcer(rc.KubegresContext, rc.ResourcesStates, rc.BlockingOperation, rc.StatefulSetsSpecsEnforcer)
 }

--- a/controllers/spec/enforcer/statefulset_spec/ServiceAccountNameSpecEnforcer.go
+++ b/controllers/spec/enforcer/statefulset_spec/ServiceAccountNameSpecEnforcer.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 Reactive Tech Limited.
+"Reactive Tech Limited" is a company located in England, United Kingdom.
+https://www.reactive-tech.io
+Lead Developer: Alex Arica
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset_spec
+
+import (
+	apps "k8s.io/api/apps/v1"
+	"reactive-tech.io/kubegres/controllers/ctx"
+)
+
+type ServiceAccountNameSpecEnforcer struct {
+	kubegresContext ctx.KubegresContext
+}
+
+func CreateServiceAccountNameSpecEnforcer(kubegresContext ctx.KubegresContext) ServiceAccountNameSpecEnforcer {
+	return ServiceAccountNameSpecEnforcer{kubegresContext: kubegresContext}
+}
+
+func (r *ServiceAccountNameSpecEnforcer) GetSpecName() string {
+	return "ServiceAccountName"
+}
+
+func (r *ServiceAccountNameSpecEnforcer) CheckForSpecDifference(statefulSet *apps.StatefulSet) StatefulSetSpecDifference {
+
+	current := statefulSet.Spec.Template.Spec.ServiceAccountName
+	expected := r.kubegresContext.Kubegres.Spec.ServiceAccountName
+
+	if current != expected {
+		return StatefulSetSpecDifference{
+			SpecName: r.GetSpecName(),
+			Current:  current,
+			Expected: expected,
+		}
+	}
+
+	return StatefulSetSpecDifference{}
+}
+
+func (r *ServiceAccountNameSpecEnforcer) EnforceSpec(statefulSet *apps.StatefulSet) (wasSpecUpdated bool, err error) {
+	statefulSet.Spec.Template.Spec.ServiceAccountName = r.kubegresContext.Kubegres.Spec.ServiceAccountName
+	return true, nil
+}
+
+func (r *ServiceAccountNameSpecEnforcer) OnSpecEnforcedSuccessfully(_ *apps.StatefulSet) error {
+	return nil
+}

--- a/controllers/spec/template/ResourcesCreatorFromTemplate.go
+++ b/controllers/spec/template/ResourcesCreatorFromTemplate.go
@@ -264,6 +264,10 @@ func (r *ResourcesCreatorFromTemplate) initStatefulSet(
 	if postgresSpec.Probe.ReadinessProbe != nil {
 		statefulSetTemplate.Spec.Template.Spec.Containers[0].ReadinessProbe = postgresSpec.Probe.ReadinessProbe
 	}
+
+	if postgresSpec.ServiceAccountName != "" {
+		statefulSetTemplate.Spec.Template.Spec.ServiceAccountName = postgresSpec.ServiceAccountName
+	}
 }
 
 // Extract annotations set in Kubegres YAML by

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -978,6 +978,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountName:
+                type: string
               volume:
                 properties:
                   volumeClaimTemplates:
@@ -2452,7 +2454,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: reactivetechio/kubegres:1.16
+        image: tetrate/kubegres:v1.16.0-tetrate-v5
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test/resourceConfigs/ConfigForTest.go
+++ b/test/resourceConfigs/ConfigForTest.go
@@ -40,6 +40,9 @@ const (
 	SecretYamlFile     = "resourceConfigs/secret.yaml"
 	SecretResourceName = "my-kubegres-secret"
 
+	ServiceAccountYamlFile     = "resourceConfigs/serviceAccount.yaml"
+	ServiceAccountResourceName = "my-kubegres"
+
 	ServiceToSqlQueryPrimaryDbYamlFile     = "resourceConfigs/primaryService.yaml"
 	ServiceToSqlQueryPrimaryDbResourceName = "test-kubegres-primary"
 	ServiceToSqlQueryPrimaryDbNodePort     = 30007

--- a/test/resourceConfigs/LoadTestYaml.go
+++ b/test/resourceConfigs/LoadTestYaml.go
@@ -22,10 +22,11 @@ package resourceConfigs
 
 import (
 	"io/ioutil"
+	"log"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"log"
 	kubegresv1 "reactive-tech.io/kubegres/api/v1"
 )
 
@@ -51,6 +52,12 @@ func LoadSecretYaml() v1.Secret {
 	fileContents := getFileContents(SecretYamlFile)
 	obj := decodeYaml(fileContents)
 	return *obj.(*v1.Secret)
+}
+
+func LoadServiceAccountYaml() v1.ServiceAccount {
+	fileContents := getFileContents(ServiceAccountYamlFile)
+	obj := decodeYaml(fileContents)
+	return *obj.(*v1.ServiceAccount)
 }
 
 func LoadYamlServiceToSqlQueryPrimaryDb() v1.Service {

--- a/test/resourceConfigs/serviceAccount.yaml
+++ b/test/resourceConfigs/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-kubegres
+  namespace: default

--- a/test/spec_serviceAccountName_test.go
+++ b/test/spec_serviceAccountName_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2023 Reactive Tech Limited.
+"Reactive Tech Limited" is a company located in England, United Kingdom.
+https://www.reactive-tech.io
+Lead Developer: Alex Arica
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"log"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	postgresv1 "reactive-tech.io/kubegres/api/v1"
+	"reactive-tech.io/kubegres/controllers/ctx"
+	"reactive-tech.io/kubegres/test/resourceConfigs"
+	"reactive-tech.io/kubegres/test/util"
+	"reactive-tech.io/kubegres/test/util/testcases"
+)
+
+var _ = Describe("Setting Kubegres spec 'serviceAccountName'", func() {
+
+	var test = SpecServiceAccountNameTest{}
+
+	BeforeEach(func() {
+		namespace := resourceConfigs.DefaultNamespace
+		test.resourceRetriever = util.CreateTestResourceRetriever(k8sClientTest, namespace)
+		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
+		test.dbQueryTestCases = testcases.InitDbQueryTestCases(test.resourceCreator, resourceConfigs.KubegresResourceName)
+	})
+
+	AfterEach(func() {
+		if !test.keepCreatedResourcesForNextTest {
+			test.resourceCreator.DeleteAllTestResources()
+		} else {
+			test.keepCreatedResourcesForNextTest = false
+		}
+	})
+
+	Context("GIVEN new Kubegres is created without spec 'serviceAccountName' and with spec 'replica' set to 3", func() {
+
+		It("THEN 1 primary and 2 replica should be created with serviceAccountName 'default' and a normal event should be logged", func() {
+
+			log.Print("START OF: Test 'GIVEN new Kubegres is created without spec 'serviceAccountName' and with spec 'replica' set to 3'")
+
+			test.givenNewKubegresSpecIsSetTo("", 3)
+
+			test.whenKubegresIsCreated()
+
+			test.thenPodsStatesShouldBe(ctx.DefaultPodServiceAccountName, 1, 2)
+
+			test.thenDeployedKubegresSpecShouldBeSetTo("")
+
+			test.dbQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
+			test.dbQueryTestCases.ThenWeCanSqlQueryReplicaDb()
+
+			log.Print("END OF: Test 'GIVEN new Kubegres is created without spec 'serviceAccountName' and with spec 'replica' set to 3'")
+		})
+	})
+
+	Context("GIVEN new Kubegres is created with spec 'serviceAccountName' set to 'my-kubegres' and spec 'replica' set to 3 and later 'serviceAccountName' is updated to 'changed-kubegres'", func() {
+
+		It("GIVEN new Kubegres is created with spec 'serviceAccountName' set to 'my-kubegres' and spec 'replica' set to 3 THEN 1 primary and 2 replica should be created with spec 'serviceAccountName' set to 'kubegres", func() {
+
+			log.Print("START OF: Test 'GIVEN new Kubegres is created with spec 'serviceAccountName' set to 'my-kubegres' and spec 'replica' set to 3")
+
+			test.whenServiceAccountIsCreated("my-kubegres")
+
+			test.givenNewKubegresSpecIsSetTo("my-kubegres", 3)
+
+			test.whenKubegresIsCreated()
+
+			test.thenPodsStatesShouldBe("my-kubegres", 1, 2)
+
+			test.thenDeployedKubegresSpecShouldBeSetTo("my-kubegres")
+
+			test.dbQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
+			test.dbQueryTestCases.ThenWeCanSqlQueryReplicaDb()
+
+			test.keepCreatedResourcesForNextTest = true
+
+			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'serviceAccountName' set to 'my-kubegres' and spec 'replica' set to 3'")
+		})
+
+		It("GIVEN existing Kubegres is updated with spec 'serviceAccountName' set from 'my-kubegres' to 'changed-kubegres' THEN 1 primary and 2 replica should be re-deployed with spec 'serviceAccountName' set to 'changed-kubegres'", func() {
+
+			log.Print("START OF: Test 'GIVEN existing Kubegres is updated with spec 'serviceAccountName' set from 'my-kubegres' to 'changed-kubegres'")
+
+			test.whenServiceAccountIsCreated("changed-kubegres")
+
+			test.givenExistingKubegresSpecIsSetTo("changed-kubegres")
+
+			test.whenKubernetesIsUpdated()
+
+			test.thenPodsStatesShouldBe("changed-kubegres", 1, 2)
+
+			test.thenDeployedKubegresSpecShouldBeSetTo("changed-kubegres")
+
+			test.dbQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
+			test.dbQueryTestCases.ThenWeCanSqlQueryReplicaDb()
+
+			log.Print("END OF: Test 'GIVEN existing Kubegres is updated with spec 'serviceAccountName' set from 'my-kubegres' to 'changed-kubegres'")
+		})
+	})
+
+})
+
+type SpecServiceAccountNameTest struct {
+	keepCreatedResourcesForNextTest bool
+	kubegresResource                *postgresv1.Kubegres
+	dbQueryTestCases                testcases.DbQueryTestCases
+	resourceCreator                 util.TestResourceCreator
+	resourceRetriever               util.TestResourceRetriever
+}
+
+func (r *SpecServiceAccountNameTest) givenNewKubegresSpecIsSetTo(serviceAccountName string, specNbreReplicas int32) {
+	r.kubegresResource = resourceConfigs.LoadKubegresYaml()
+	r.kubegresResource.Spec.Replicas = &specNbreReplicas
+	if serviceAccountName != "" {
+		r.kubegresResource.Spec.ServiceAccountName = serviceAccountName
+	}
+}
+
+func (r *SpecServiceAccountNameTest) givenExistingKubegresSpecIsSetTo(serviceAccountName string) {
+	var err error
+	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+
+	if err != nil {
+		log.Println("Error while getting Kubegres resource : ", err)
+		Expect(err).Should(Succeed())
+		return
+	}
+
+	r.kubegresResource.Spec.ServiceAccountName = serviceAccountName
+}
+
+func (r *SpecServiceAccountNameTest) whenKubegresIsCreated() {
+	r.resourceCreator.CreateKubegres(r.kubegresResource)
+}
+
+func (r *SpecServiceAccountNameTest) whenKubernetesIsUpdated() {
+	r.resourceCreator.UpdateResource(r.kubegresResource, "Kubegres")
+}
+
+func (r *SpecServiceAccountNameTest) thenPodsStatesShouldBe(serviceAccountName string, nbrePrimary, nbreReplicas int) bool {
+	return Eventually(func() bool {
+
+		kubegresResources, err := r.resourceRetriever.GetKubegresResources()
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.Println("ERROR while retrieving Kubegres kubegresResources")
+			return false
+		}
+
+		for _, resource := range kubegresResources.Resources {
+			currentServiceAccountName := resource.Pod.Spec.ServiceAccountName
+			if currentServiceAccountName != serviceAccountName {
+				log.Println("Pod '" + resource.Pod.Name + "' doesn't have the expected serviceAccountName: '" + serviceAccountName + "'. " +
+					"Current value: '" + currentServiceAccountName + "'. Waiting...")
+				return false
+			}
+		}
+
+		if kubegresResources.AreAllReady &&
+			kubegresResources.NbreDeployedPrimary == nbrePrimary &&
+			kubegresResources.NbreDeployedReplicas == nbreReplicas {
+
+			time.Sleep(resourceConfigs.TestRetryInterval)
+			log.Println("Deployed and Ready StatefulSets check successful")
+			return true
+		}
+
+		return false
+
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
+}
+
+func (r *SpecServiceAccountNameTest) thenDeployedKubegresSpecShouldBeSetTo(serviceAccountName string) {
+	var err error
+	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+
+	if err != nil {
+		log.Println("Error while getting Kubegres resource : ", err)
+		Expect(err).Should(Succeed())
+		return
+	}
+
+	Expect(r.kubegresResource.Spec.ServiceAccountName).Should(Equal(serviceAccountName))
+}
+
+func (r *SpecServiceAccountNameTest) whenServiceAccountIsCreated(serviceAccountName string) {
+	r.resourceCreator.CreateServiceAccount(serviceAccountName)
+}

--- a/test/util/TestResourceCreator.go
+++ b/test/util/TestResourceCreator.go
@@ -22,17 +22,18 @@ package util
 
 import (
 	"context"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"log"
 	postgresv1 "reactive-tech.io/kubegres/api/v1"
 	resourceConfigs2 "reactive-tech.io/kubegres/test/resourceConfigs"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"time"
 )
 
 type TestResourceCreator struct {
@@ -182,6 +183,24 @@ func (r *TestResourceCreator) CreateServiceToSqlQueryDb(kubegresName string, nod
 	resourceLabel := "Service " + serviceResourceName + " (nodePort: " + strconv.Itoa(nodePort) + ")"
 
 	return r.createResourceFromYaml(resourceLabel, serviceResourceName, &existingResource, &resourceToCreate)
+}
+
+func (r *TestResourceCreator) CreateServiceAccount(serviceAccountName string) {
+	existingResource := v1.ServiceAccount{}
+	resourceToCreate := resourceConfigs2.LoadServiceAccountYaml()
+	resourceToCreate.Namespace = r.namespace
+	resourceToCreate.Name = resourceConfigs2.ServiceAccountResourceName
+
+	if serviceAccountName != "" {
+		resourceToCreate.Name = serviceAccountName
+	}
+	_, err := r.createResourceFromYaml("ServiceAccount", resourceToCreate.Name, &existingResource, &resourceToCreate)
+	if err != nil {
+		log.Println("Error while creating ServiceAccount resource : ", err)
+		gomega.Expect(err).Should(gomega.Succeed())
+	} else {
+		log.Println("ServiceAccount resource created")
+	}
 }
 
 func (r *TestResourceCreator) DeleteResource(resourceToDelete client.Object, resourceName string) bool {


### PR DESCRIPTION
Brings back PRs:
- #3 
- #4 

Before the mentioned PRs were merged, the base branch was modified with a force push causing the loss of some commits.

The base branch has been recovered and this PR brings back the mentioned PRs.