### PR TITLE
Also apply volumes and custom configs from spec to init containers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,9 +17,10 @@ env:
 
 jobs:
   # All test running sequentially take around ~2h.
-  # Sppliting them in groups that take more or less the same time makes PR's readiness faster
+  # Splitting them in groups that take more or less the same time makes PR's readiness faster
   test-group:
     strategy:
+      fail-fast: false
       matrix:
         label:
           - "group:1"

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/failover/PrimaryToReplicaFailOver.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/failover/PrimaryToReplicaFailOver.go
@@ -22,13 +22,14 @@ package failover
 
 import (
 	"errors"
+	"strconv"
+
 	core "k8s.io/api/core/v1"
 	v1 "reactive-tech.io/kubegres/api/v1"
 	"reactive-tech.io/kubegres/controllers/ctx"
 	"reactive-tech.io/kubegres/controllers/operation"
 	"reactive-tech.io/kubegres/controllers/states"
 	"reactive-tech.io/kubegres/controllers/states/statefulset"
-	"strconv"
 )
 
 type PrimaryToReplicaFailOver struct {
@@ -244,9 +245,9 @@ func (r *PrimaryToReplicaFailOver) promoteReplicaToPrimary(newPrimary statefulse
 	newPrimary.StatefulSet.Labels["replicationRole"] = ctx.PrimaryRoleName
 	newPrimary.StatefulSet.Spec.Template.Labels["replicationRole"] = ctx.PrimaryRoleName
 	volumeMount := core.VolumeMount{
-		Name:      "base-config",
+		Name:      r.resourcesStates.Config.ConfigLocations.PromoteReplica,
 		MountPath: "/tmp/promote_replica_to_primary.sh",
-		SubPath:   "promote_replica_to_primary.sh",
+		SubPath:   states.ConfigMapDataKeyPromoteReplica,
 	}
 
 	initContainer := &newPrimary.StatefulSet.Spec.Template.Spec.InitContainers[0]

--- a/controllers/spec/enforcer/statefulset_spec/CustomConfigSpecEnforcer.go
+++ b/controllers/spec/enforcer/statefulset_spec/CustomConfigSpecEnforcer.go
@@ -39,8 +39,10 @@ func (r *CustomConfigSpecEnforcer) GetSpecName() string {
 
 func (r *CustomConfigSpecEnforcer) CheckForSpecDifference(statefulSet *apps.StatefulSet) StatefulSetSpecDifference {
 
-	statefulSetCopy := *statefulSet
-	hasStatefulSetChanged, changesDetails := r.customConfigSpecHelper.ConfigureStatefulSet(&statefulSetCopy)
+	// We need to create a deep copy of the statefulSet to avoid modifying the original object, as we are only checking for differences.
+	// Original statefulSet will be modified by the EnforceSpec method.
+	statefulSetCopy := statefulSet.DeepCopy()
+	hasStatefulSetChanged, changesDetails := r.customConfigSpecHelper.ConfigureStatefulSet(statefulSetCopy)
 
 	if hasStatefulSetChanged {
 		return StatefulSetSpecDifference{
@@ -58,6 +60,6 @@ func (r *CustomConfigSpecEnforcer) EnforceSpec(statefulSet *apps.StatefulSet) (w
 	return wasSpecUpdated, nil
 }
 
-func (r *CustomConfigSpecEnforcer) OnSpecEnforcedSuccessfully(statefulSet *apps.StatefulSet) error {
+func (r *CustomConfigSpecEnforcer) OnSpecEnforcedSuccessfully(*apps.StatefulSet) error {
 	return nil
 }

--- a/controllers/spec/enforcer/statefulset_spec/CustomMetadataSpecEnforcer.go
+++ b/controllers/spec/enforcer/statefulset_spec/CustomMetadataSpecEnforcer.go
@@ -68,17 +68,22 @@ func extractCustom(src map[string]string) map[string]string {
 
 func (r *CustomMetadataSpecEnforcer) EnforceSpec(statefulSet *apps.StatefulSet) (bool, error) {
 	md := getCustomMetadata(r.kubegresContext.Kubegres.GetObjectMeta())
-	merge(statefulSet.ObjectMeta.Labels, md.Labels)
-	merge(statefulSet.ObjectMeta.Annotations, md.Annotations)
-	merge(statefulSet.Spec.Template.ObjectMeta.Labels, md.Labels)
-	merge(statefulSet.Spec.Template.ObjectMeta.Annotations, md.Annotations)
+	statefulSet.ObjectMeta.Labels = merge(statefulSet.ObjectMeta.Labels, md.Labels)
+	statefulSet.ObjectMeta.Annotations = merge(statefulSet.ObjectMeta.Annotations, md.Annotations)
+	statefulSet.Spec.Template.ObjectMeta.Labels = merge(statefulSet.Spec.Template.ObjectMeta.Labels, md.Labels)
+	statefulSet.Spec.Template.ObjectMeta.Annotations = merge(statefulSet.Spec.Template.ObjectMeta.Annotations, md.Annotations)
 	return true, nil
 }
 
-func merge(dst map[string]string, src map[string]string) {
-	for key, value := range src {
-		dst[key] = value
+func merge(a map[string]string, b map[string]string) map[string]string {
+	result := make(map[string]string, len(a)+len(b))
+	for key, value := range a {
+		result[key] = value
 	}
+	for key, value := range b {
+		result[key] = value
+	}
+	return result
 }
 
 func (r *CustomMetadataSpecEnforcer) OnSpecEnforcedSuccessfully(*apps.StatefulSet) error {

--- a/controllers/spec/enforcer/statefulset_spec/VolumeSpecEnforcer.go
+++ b/controllers/spec/enforcer/statefulset_spec/VolumeSpecEnforcer.go
@@ -59,7 +59,7 @@ func (r *VolumeSpecEnforcer) CheckForSpecDifference(statefulSet *apps.StatefulSe
 
 	if hasInitContainer && !r.compareVolumeMounts(currentCustomVolumeMountsInit, expectedCustomVolumeMounts) {
 		return StatefulSetSpecDifference{
-			SpecName: "Volume.VolumeMounts",
+			SpecName: "Volume.VolumeMounts[initContainer]",
 			Current:  r.volumeMountsToString(currentCustomVolumeMountsInit),
 			Expected: r.volumeMountsToString(expectedCustomVolumeMounts),
 		}
@@ -67,7 +67,7 @@ func (r *VolumeSpecEnforcer) CheckForSpecDifference(statefulSet *apps.StatefulSe
 
 	if !r.compareVolumeMounts(currentCustomVolumeMounts, expectedCustomVolumeMounts) {
 		return StatefulSetSpecDifference{
-			SpecName: "Volume.VolumeMounts",
+			SpecName: "Volume.VolumeMounts[container]",
 			Current:  r.volumeMountsToString(currentCustomVolumeMounts),
 			Expected: r.volumeMountsToString(expectedCustomVolumeMounts),
 		}

--- a/controllers/spec/template/CustomConfigSpecHelper.go
+++ b/controllers/spec/template/CustomConfigSpecHelper.go
@@ -69,10 +69,7 @@ func (r *CustomConfigSpecHelper) ConfigureStatefulSet(statefulSet *v1.StatefulSe
 		hasStatefulSetChanged = true
 	}
 
-	if r.updateVolumeMountNameIfChanged(configMap.ConfigLocations.PromoteReplica, states.ConfigMapDataKeyPromoteReplica, statefulSet) {
-		differenceDetails += r.createDescriptionMsg(configMap.ConfigLocations.PromoteReplica, states.ConfigMapDataKeyPromoteReplica)
-		hasStatefulSetChanged = true
-	}
+	// No need to check for states.ConfigMapDataKeyPromoteReplica as this is only used by the failover enforcer
 
 	statefulSetTemplateSpec := &statefulSet.Spec.Template.Spec
 
@@ -125,16 +122,6 @@ func (r *CustomConfigSpecHelper) updateVolumeMountNameIfChanged(volumeName, conf
 
 func (r *CustomConfigSpecHelper) createDescriptionMsg(volumeMountName, configMapDataKey string) string {
 	return "VolumeMount with subPath: '" + configMapDataKey + "' was updated to name: '" + volumeMountName + "' - "
-}
-
-func (r *CustomConfigSpecHelper) getVolumeMountIndex(configMapDataKey string, statefulSet *v1.StatefulSet) int {
-	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	for i := 0; i < len(volumeMounts); i++ {
-		if volumeMounts[i].SubPath == configMapDataKey {
-			return i
-		}
-	}
-	return -1
 }
 
 func (r *CustomConfigSpecHelper) getCustomConfigMapVolume(volumes []core.Volume) *core.Volume {

--- a/controllers/spec/template/ResourcesCreatorFromTemplate.go
+++ b/controllers/spec/template/ResourcesCreatorFromTemplate.go
@@ -251,6 +251,9 @@ func (r *ResourcesCreatorFromTemplate) initStatefulSet(
 
 	if postgresSpec.Volume.VolumeMounts != nil {
 		statefulSetTemplate.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSetTemplate.Spec.Template.Spec.Containers[0].VolumeMounts, r.kubegresContext.Kubegres.Spec.Volume.VolumeMounts...)
+		if len(statefulSetTemplate.Spec.Template.Spec.InitContainers) > 0 {
+			statefulSetTemplate.Spec.Template.Spec.InitContainers[0].VolumeMounts = append(statefulSetTemplate.Spec.Template.Spec.InitContainers[0].VolumeMounts, r.kubegresContext.Kubegres.Spec.Volume.VolumeMounts...)
+		}
 	}
 
 	if postgresSpec.SecurityContext != nil {

--- a/controllers/states/ConfigStates.go
+++ b/controllers/states/ConfigStates.go
@@ -28,10 +28,13 @@ import (
 )
 
 const (
-	ConfigMapDataKeyPostgresConf      = "postgres.conf"
-	ConfigMapDataKeyPrimaryInitScript = "primary_init_script.sh"
-	ConfigMapDataKeyPgHbaConf         = "pg_hba.conf"
-	ConfigMapDataKeyBackUpScript      = "backup_database.sh"
+	ConfigMapDataKeyPostgresConf             = "postgres.conf"
+	ConfigMapDataKeyPrimaryInitScript        = "primary_init_script.sh"
+	ConfigMapDataKeyPgHbaConf                = "pg_hba.conf"
+	ConfigMapDataKeyBackUpScript             = "backup_database.sh"
+	ConfigMapDataKeyCopyPrimaryDataToReplica = "copy_primary_data_to_replica.sh"
+	ConfigMapDataKeyPrimaryCreateReplicaRole = "primary_create_replication_role.sh"
+	ConfigMapDataKeyPromoteReplica           = "promote_replica_to_primary.sh"
 )
 
 type ConfigStates struct {
@@ -46,10 +49,13 @@ type ConfigStates struct {
 
 // Stores as string the volume-name for each config-type which can be either 'base-config' or 'custom-config'
 type ConfigLocations struct {
-	PostgreConf       string
-	PrimaryInitScript string
-	BackUpScript      string
-	PgHbaConf         string
+	PostgreConf              string
+	PrimaryInitScript        string
+	BackUpScript             string
+	PgHbaConf                string
+	CopyPrimaryDataToReplica string
+	PrimaryCreateReplicaRole string
+	PromoteReplica           string
 }
 
 func loadConfigStates(kubegresContext ctx.KubegresContext) (ConfigStates, error) {
@@ -69,6 +75,9 @@ func (r *ConfigStates) loadStates() (err error) {
 	r.ConfigLocations.PrimaryInitScript = ctx.BaseConfigMapVolumeName
 	r.ConfigLocations.BackUpScript = ctx.BaseConfigMapVolumeName
 	r.ConfigLocations.PgHbaConf = ctx.BaseConfigMapVolumeName
+	r.ConfigLocations.CopyPrimaryDataToReplica = ctx.BaseConfigMapVolumeName
+	r.ConfigLocations.PrimaryCreateReplicaRole = ctx.BaseConfigMapVolumeName
+	r.ConfigLocations.PromoteReplica = ctx.BaseConfigMapVolumeName
 
 	baseConfigMap, err := r.getBaseDeployedConfigMap()
 	if err != nil {
@@ -106,6 +115,18 @@ func (r *ConfigStates) loadStates() (err error) {
 
 		if customConfigMap.Data[ConfigMapDataKeyPgHbaConf] != "" {
 			r.ConfigLocations.PgHbaConf = ctx.CustomConfigMapVolumeName
+		}
+
+		if customConfigMap.Data[ConfigMapDataKeyCopyPrimaryDataToReplica] != "" {
+			r.ConfigLocations.CopyPrimaryDataToReplica = ctx.CustomConfigMapVolumeName
+		}
+
+		if customConfigMap.Data[ConfigMapDataKeyPrimaryCreateReplicaRole] != "" {
+			r.ConfigLocations.PrimaryCreateReplicaRole = ctx.CustomConfigMapVolumeName
+		}
+
+		if customConfigMap.Data[ConfigMapDataKeyPromoteReplica] != "" {
+			r.ConfigLocations.PromoteReplica = ctx.CustomConfigMapVolumeName
 		}
 	}
 

--- a/test/resourceConfigs/ConfigForTest.go
+++ b/test/resourceConfigs/ConfigForTest.go
@@ -75,4 +75,7 @@ const (
 
 	CustomConfigMapWithPostgresConfAndWalLevelSetToLogicalResourceName = "config-with-postgres-conf-wal-level-to-logical"
 	CustomConfigMapWithPostgresConfAndWalLevelSetToLogicalYamlFile     = "resourceConfigs/customConfig/configMap_with_postgres_conf_and_wal_level_to_logical.yaml"
+
+	CustomConfigMapWithPromoteReplicaScriptResourceName = "config-with-promote-replica-script"
+	CustomConfigMapWithPromoteReplicaScriptYamlFile     = "resourceConfigs/customConfig/configMap_with_promote_replica_script.yaml"
 )

--- a/test/resourceConfigs/ConfigForTest.go
+++ b/test/resourceConfigs/ConfigForTest.go
@@ -78,4 +78,7 @@ const (
 
 	CustomConfigMapWithPromoteReplicaScriptResourceName = "config-with-promote-replica-script"
 	CustomConfigMapWithPromoteReplicaScriptYamlFile     = "resourceConfigs/customConfig/configMap_with_promote_replica_script.yaml"
+
+	CustomConfigMapWithPrimaryCreateReplicationRoleResourceName = "config-with-primary-create-replication-role-script"
+	CustomConfigMapwithPrimaryCreateReplicationRoleYamlFile     = "resourceConfigs/customConfig/configMap_with_primary_create_replication_role_script.yaml"
 )

--- a/test/resourceConfigs/customConfig/configMap_with_primary_create_replication_role_script.yaml
+++ b/test/resourceConfigs/customConfig/configMap_with_primary_create_replication_role_script.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-with-primary-create-replication-role-script
+  namespace: default
+  labels:
+    environment: acceptancetesting
+
+data:
+
+  postgres.conf: |
+    # Replication configs
+    listen_addresses = '*'
+    max_wal_senders = 10
+    max_connections = 100
+    shared_buffers = 128MB
+
+    # Logging
+    #log_destination = 'stderr,csvlog'
+    #logging_collector = on
+    #log_directory = 'pg_log'
+    #log_filename= 'postgresql-%Y-%m-%d_%H%M%S.log'
+
+  primary_create_replication_role.sh: |
+    #!/bin/bash
+    set -e
+    
+    dt=$(date '+%d/%m/%Y %H:%M:%S');
+    echo "$dt - Creating replication role...";
+    echo "$dt - Running: psql -v ON_ERROR_STOP=1 --username $POSTGRES_USER --dbname $POSTGRES_DB ... CREATE ROLE replication WITH REPLICATION PASSWORD ... GRANT EXECUTE ON FUNCTION pg_promote TO replication;";
+    
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE ROLE replication WITH REPLICATION PASSWORD '$POSTGRES_REPLICATION_PASSWORD' LOGIN;
+    GRANT EXECUTE ON FUNCTION pg_promote TO replication;
+    EOSQL
+    
+    echo "$dt - Replication role created";

--- a/test/resourceConfigs/customConfig/configMap_with_promote_replica_script.yaml
+++ b/test/resourceConfigs/customConfig/configMap_with_promote_replica_script.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-with-promote-replica-script
+  namespace: default
+  labels:
+    environment: acceptancetesting
+
+data:
+
+  promote_replica_to_primary.sh: |
+    #!/bin/bash
+    set -e
+
+    dt=$(date '+%d/%m/%Y %H:%M:%S');
+    echo "$dt - Attempting to promote a Replica PostgreSql to Primary...";
+
+    standbyFilePath="$PGDATA/standby.signal"
+
+    if [ ! -f "$standbyFilePath" ]; then
+      echo "$dt - Skipping as this PostgreSql is already a Primary since the file '$standbyFilePath' does not exist."
+      exit 0
+    fi
+
+    promotionTriggerFilePath="$PGDATA/promote_replica_to_primary.log"
+
+    if [ -f "$promotionTriggerFilePath" ]; then
+      echo "$dt - Skipping as the promotion trigger file '$promotionTriggerFilePath' already exists"
+      exit 0
+    fi
+
+    echo "$dt - Promoting by creating the promotion trigger file: '$promotionTriggerFilePath'"
+    touch $promotionTriggerFilePath

--- a/test/spec_customConfig_test.go
+++ b/test/spec_customConfig_test.go
@@ -75,11 +75,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsShouldNotContainsCustomConfig()
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			test.thenDeployedKubegresSpecShouldBeSetTo(ctx.BaseConfigMapName)
 
@@ -117,11 +123,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapEmptyResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'customConfig' set to a ConfigMap which is empty'")
 		})
@@ -141,11 +153,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapWithPostgresConfResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'customConfig' set to a ConfigMap containing 'postgres.conf'")
 		})
@@ -165,11 +183,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapWithPrimaryInitScriptResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'customConfig' set to a ConfigMap containing 'primary_init_script.sh''")
 		})
@@ -189,11 +213,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapWithPgHbaConfResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'customConfig' set to a ConfigMap containing 'pg_hba.conf''")
 		})
@@ -220,11 +250,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapWithPostgresConfResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.CustomConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			test.dbQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.dbQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -249,11 +285,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenPodsContainsCustomConfigWithResourceName(resourceConfigs.CustomConfigMapWithBackupDatabaseScriptResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with backUp enabled and spec 'customConfig' set to a ConfigMap containing 'backup_database.sh''")
 		})
@@ -261,7 +303,7 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 	Context("GIVEN new Kubegres is created with backUp enabled and spec 'customConfig' set to base-config AND later it is updated to a configMap containing data-key 'backup_database.sh'", func() {
 
-		It("THEN the custom-config should be used for 'postgres.conf' AND the base-config should be used for 'postgres.conf', 'pg_hba.conf' and 'primary_init_script.sh'", func() {
+		It("THEN the custom-config should be used for 'backup_database.conf' AND the base-config should be used for 'postgres.conf', 'pg_hba.conf' and 'primary_init_script.sh'", func() {
 
 			log.Print("START OF: Test 'GIVEN new Kubegres is created with backUp enabled and spec 'customConfig' set to base-config AND later it is updated to a configMap containing data-key 'backup_database.sh''")
 
@@ -284,11 +326,17 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 
 			test.thenCronJobContainsConfigMap(resourceConfigs.CustomConfigMapWithBackupDatabaseScriptResourceName)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, replica)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, true)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryInitScript, primary)
 
-			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPostgresConf, false)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, primary)
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPgHbaConf, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyCopyPrimaryDataToReplica, replica)
+
+			test.thenPodsContainsConfigTypeAssociatedToFile(ctx.BaseConfigMapVolumeName, states.ConfigMapDataKeyPrimaryCreateReplicaRole, primary)
 
 			test.dbQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.dbQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -439,7 +487,14 @@ func (r *SpecCustomConfigTest) hasCustomConfigWithResourceName(statefulSetSpec v
 	return false
 }
 
-func (r *SpecCustomConfigTest) thenPodsContainsConfigTypeAssociatedToFile(expectedVolumeNameForConfigType, expectedConfigFile string, isOnlyPrimaryStatefulSet bool) bool {
+type statefulSetType int
+
+const (
+	primary statefulSetType = iota
+	replica
+)
+
+func (r *SpecCustomConfigTest) thenPodsContainsConfigTypeAssociatedToFile(expectedVolumeNameForConfigType, expectedConfigFile string, statefulSetType statefulSetType) bool {
 	return Eventually(func() bool {
 
 		kubegresResources, err := r.resourceRetriever.GetKubegresResources()
@@ -450,7 +505,10 @@ func (r *SpecCustomConfigTest) thenPodsContainsConfigTypeAssociatedToFile(expect
 
 		for _, resource := range kubegresResources.Resources {
 
-			if isOnlyPrimaryStatefulSet && !resource.IsPrimary {
+			switch {
+			case statefulSetType == primary && !resource.IsPrimary:
+				continue
+			case statefulSetType == replica && resource.IsPrimary:
 				continue
 			}
 
@@ -497,6 +555,13 @@ func (r *SpecCustomConfigTest) hasConfigTypeAssociatedToFile(statefulSetSpec v1.
 	for _, volumeMount := range statefulSetSpec.Template.Spec.Containers[0].VolumeMounts {
 		if volumeMount.Name == expectedVolumeNameForConfigType && volumeMount.SubPath == expectedConfigFile {
 			return true
+		}
+	}
+	if len(statefulSetSpec.Template.Spec.InitContainers) > 0 {
+		for _, volumeMount := range statefulSetSpec.Template.Spec.InitContainers[0].VolumeMounts {
+			if volumeMount.Name == expectedVolumeNameForConfigType && volumeMount.SubPath == expectedConfigFile {
+				return true
+			}
 		}
 	}
 	return false

--- a/test/spec_customConfig_test.go
+++ b/test/spec_customConfig_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 		test.resourceCreator.CreateConfigMapWithPgHbaConf()
 		test.resourceCreator.CreateConfigMapWithPostgresConf()
 		test.resourceCreator.CreateConfigMapWithPrimaryInitScript()
+		test.resourceCreator.CreateConfigMapWithPromoteReplicaScript()
 	})
 
 	AfterEach(func() {
@@ -344,7 +345,6 @@ var _ = Describe("Setting Kubegres specs 'customConfig'", Label("group:2"), func
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with backUp enabled and spec 'customConfig' set to base-config AND later it is updated to a configMap containing data-key 'backup_database.sh''")
 		})
 	})
-
 })
 
 type SpecCustomConfigTest struct {

--- a/test/spec_volumeAndVolumeMount_test.go
+++ b/test/spec_volumeAndVolumeMount_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Setting Kubegres specs 'volume.volume' and 'volume.volumeMount
 		namespace := resourceConfigs.DefaultNamespace
 		test.resourceRetriever = util.CreateTestResourceRetriever(k8sClientTest, namespace)
 		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
-		//test.dbQueryTestCases = testcases.InitDbQueryTestCases(test.resourceCreator, resourceConfigs.KubegresResourceName)
+		test.dbQueryTestCases = testcases.InitDbQueryTestCases(test.resourceCreator, resourceConfigs.KubegresResourceName)
 	})
 
 	AfterEach(func() {

--- a/test/spec_volumeAndVolumeMount_test.go
+++ b/test/spec_volumeAndVolumeMount_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Setting Kubegres specs 'volume.volume' and 'volume.volumeMount
 		namespace := resourceConfigs.DefaultNamespace
 		test.resourceRetriever = util.CreateTestResourceRetriever(k8sClientTest, namespace)
 		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
-		test.dbQueryTestCases = testcases.InitDbQueryTestCases(test.resourceCreator, resourceConfigs.KubegresResourceName)
+		//test.dbQueryTestCases = testcases.InitDbQueryTestCases(test.resourceCreator, resourceConfigs.KubegresResourceName)
 	})
 
 	AfterEach(func() {
@@ -141,7 +141,7 @@ var _ = Describe("Setting Kubegres specs 'volume.volume' and 'volume.volumeMount
 				"and spec 'replica' set to 3'")
 		})
 
-		It("GIVEN existing Kubegres is updated by updating by adding new and updating existing custom 'volume.volume' and 'volume.volumeMount' THEN "+
+		It("GIVEN existing Kubegres is updated by adding new and updating existing custom 'volume.volume' and 'volume.volumeMount' THEN "+
 			"StatefulSets should be updated too", func() {
 
 			log.Print("START OF: Test 'GIVEN existing Kubegres is updated by adding new and updating existing custom 'volume.volume' and 'volume.volumeMount'")
@@ -472,6 +472,13 @@ func (r *SpecVolumeAndVolumeMountTest) thenStatefulSetsStatesShouldBe(
 					log.Println("StatefulSet '" + resource.StatefulSet.Name + "' doesn't have the expected custom volumeMount with name: '" + customVolumeMount.Name + "'. Waiting...")
 					return false
 				}
+
+				if len(resource.StatefulSet.Spec.Template.Spec.InitContainers) > 0 {
+					if !r.doesCustomVolumeMountExistsInStatefulSet(customVolumeMount, resource.StatefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts) {
+						log.Println("StatefulSet '" + resource.StatefulSet.Name + "' doesn't have the expected custom volumeMount in init container with name: '" + customVolumeMount.Name + "'. Waiting...")
+						return false
+					}
+				}
 			}
 
 			for _, volumeMountInStatefulSet := range resource.StatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts {
@@ -479,6 +486,15 @@ func (r *SpecVolumeAndVolumeMountTest) thenStatefulSetsStatesShouldBe(
 					!r.isVolumeMountAnExpectedCustomVolumeMount(volumeMountInStatefulSet, expectedCustomVolumeMounts) {
 					log.Println("StatefulSet '" + resource.StatefulSet.Name + "' still has custom volumeMount with name: '" + volumeMountInStatefulSet.Name + "'. Waiting...")
 					return false
+				}
+			}
+			if len(resource.StatefulSet.Spec.Template.Spec.InitContainers) > 0 {
+				for _, volumeMountInStatefulSet := range resource.StatefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts {
+					if r.isCustomVolumeMount(volumeMountInStatefulSet, kubegresContext) &&
+						!r.isVolumeMountAnExpectedCustomVolumeMount(volumeMountInStatefulSet, expectedCustomVolumeMounts) {
+						log.Println("StatefulSet '" + resource.StatefulSet.Name + "' still has custom volumeMount in init container with name: '" + volumeMountInStatefulSet.Name + "'. Waiting...")
+						return false
+					}
 				}
 			}
 		}

--- a/test/util/TestResourceCreator.go
+++ b/test/util/TestResourceCreator.go
@@ -145,6 +145,13 @@ func (r *TestResourceCreator) CreateConfigMapWithPostgresConfAndWalLevelSetToLog
 	r.createResourceFromYaml("Custom ConfigMap with postgres conf and wal_level=logical", resourceConfigs2.CustomConfigMapWithPostgresConfAndWalLevelSetToLogicalResourceName, &existingResource, &resourceToCreate)
 }
 
+func (r *TestResourceCreator) CreateConfigMapWithPromoteReplicaScript() {
+	existingResource := v1.ConfigMap{}
+	resourceToCreate := resourceConfigs2.LoadCustomConfigMapYaml(resourceConfigs2.CustomConfigMapWithPromoteReplicaScriptYamlFile)
+	resourceToCreate.Namespace = r.namespace
+	r.createResourceFromYaml("Custom ConfigMap with promote replica script", resourceConfigs2.CustomConfigMapWithPromoteReplicaScriptResourceName, &existingResource, &resourceToCreate)
+}
+
 func (r *TestResourceCreator) CreateNamespace() {
 	if r.namespace == resourceConfigs2.DefaultNamespace {
 		return

--- a/test/util/TestResourceCreator.go
+++ b/test/util/TestResourceCreator.go
@@ -152,6 +152,13 @@ func (r *TestResourceCreator) CreateConfigMapWithPromoteReplicaScript() {
 	r.createResourceFromYaml("Custom ConfigMap with promote replica script", resourceConfigs2.CustomConfigMapWithPromoteReplicaScriptResourceName, &existingResource, &resourceToCreate)
 }
 
+func (r *TestResourceCreator) CreateConfigMapWithPrimaryCreateReplicationRoleScript() {
+	existingResource := v1.ConfigMap{}
+	resourceToCreate := resourceConfigs2.LoadCustomConfigMapYaml(resourceConfigs2.CustomConfigMapwithPrimaryCreateReplicationRoleYamlFile)
+	resourceToCreate.Namespace = r.namespace
+	r.createResourceFromYaml("Custom ConfigMap with primary create replication role script", resourceConfigs2.CustomConfigMapWithPrimaryCreateReplicationRoleResourceName, &existingResource, &resourceToCreate)
+}
+
 func (r *TestResourceCreator) CreateNamespace() {
 	if r.namespace == resourceConfigs2.DefaultNamespace {
 		return


### PR DESCRIPTION
Part of: https://github.com/tetrateio/tetrate/issues/23240

This PR applies the custom config map and the custom volumes from the Kubegres spec to the init containers from the stateful sets, as it does for the main containers.
It also makes failover to use the custom config map in case it contains the script to promote replicas.

This allows TSB to configure volumes containing the TLS certificates and custom scripts that execute replica initialization using the TLS certs to connect to the primary instance.