### PR TITLE
Fix publish release action as release-* branches are protected

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -17,8 +17,10 @@ env:
   GOPROXY: https://proxy.golang.org
 
 jobs:
-  # this job updates the kubegres.yaml with the new version is going to be released, and creates a commit and a tag with the changes
-  update-kubegres-yaml:
+  # This checks if the kubegres.yaml is up to date.
+  # We cannot make the action to update the kubegres.yaml because the release-* branches are protected,
+  # and the action would not have the permissions to push the changes.
+  check-kubegres-yaml:
     runs-on: ubuntu-latest
     env:
        IMG: tetrate/kubegres:${{ github.event.inputs.version }}
@@ -28,16 +30,13 @@ jobs:
            ref: ${{ github.event.inputs.branch }}
       - name: Update kubegres.yaml
         run: make deploy
-      - name: Commit and push changes
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: "pre-release-tag: Update kubegres.yaml to version ${{ github.event.inputs.version }}"
-          branch: ${{ github.event.inputs.branch }}
-          rebase: true
-      - name: recover new git commit sha
-        id: get-commit-sha
-        run: echo "NEW_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT" && echo "$GITHUB_OUTPUT"
+      - name: Check if there are changes
+        run: |
+          git diff --exit-code
+          if [ $? -ne 0 ]; then
+              echo "kubegres.yaml is not up to date. Run `IMG=${IMG} make deploy` to update it."
+              exit 1
+          fi
       - name: Create the tag
         uses: actions/github-script@v7
         with:
@@ -46,12 +45,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/tags/${{ github.event.inputs.version }}',
-              sha: '${{ steps.get-commit-sha.outputs.NEW_SHA }}'
+              sha: context.sha
             })
 
   # this job builds the docker image and pushes it to docker hub
   docker-hub-push:
-    needs: update-kubegres-yaml
+    needs: check-kubegres-yaml
     runs-on: ubuntu-latest
     env:
       IMG: tetrate/kubegres:${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@ and on [https://www.kubegres.io](https://www.kubegres.io). More details in the [
 
 While waiting for PRs to be accepted in the upstream repository and a new version to be released, follow the next instructions to publish our own builds:
 - Define the new version name by following the pattern `<current-version>-tetrate-v<patch-number>`, for example `v1.16.0-tetrate-v0` is the first CVEs fixing patch for v1. 16.0 kubegres.
-- Once the PR is approved:
-  - Run the Make Release including the new version name and the source branch from where make the release. This will:
-    - Update the kubegres.yaml file with the new version. By running `IMG=tetrate/kubegres:<new-version> make deploy`.
-    - Create the tag and push it to the repository, along to the new commit in the given branch.
-    - Once this action is done, the release action will be triggered and will:
-      - Scan for CVEs in the new version.
-      - Build the binaries for the new version.
-      - Build the docker images and push them to the tetrate docker hub repository.
-      - Run acceptance tests.
+- Run the command `IMG=tetrate/kubegres:<new-version> make deploy` to update the kubegres.yaml file with the new version and open a PR with the changes.
+- Once the PR is approved and merged:
+  - Run the Publish Release workflow including the new version name and the source branch from where make the release. This will:
+    - Check if the kubegres.yaml is updated with the new version. Done by the `IMG=tetrate/kubegres:<new-version> make deploy` command.
+    - Create the tag and push it to the repository.
+    - Build the binaries for the new version.
+    - Build the docker images and push them to the tetrate docker hub repository.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v11
+  newTag: v1.16.0-tetrate-v12

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2454,7 +2454,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v11
+        image: tetrate/kubegres:v1.16.0-tetrate-v12
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Due to the branch protection, when this workflow is run in the `release-v1.16.x` branch it fails due to the protection rules. And so, no release is published.

Instead, the workflow checks that the `kubegres.yaml` is up to date with the version requested to be released, if so it continues and creates the tag and publishes the images, or else the workflow fails.

At the same time, this PR is updating and preparing for the next release.