### PR TITLE
fix: propagate resources from kubegres spec to init-containers

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v15
+  newTag: blackrock-fix

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: blackrock-fix
+  newTag: blackrock-fix-in-load-tmpl

--- a/controllers/spec/enforcer/statefulset_spec/ResourcesSpecEnforcer.go
+++ b/controllers/spec/enforcer/statefulset_spec/ResourcesSpecEnforcer.go
@@ -42,6 +42,9 @@ func (r *ResourcesSpecEnforcer) GetSpecName() string {
 func (r *ResourcesSpecEnforcer) CheckForSpecDifference(statefulSet *apps.StatefulSet) StatefulSetSpecDifference {
 
 	current := statefulSet.Spec.Template.Spec.Containers[0].Resources
+	if len(statefulSet.Spec.Template.Spec.InitContainers) > 0 {
+		_ = statefulSet.Spec.Template.Spec.InitContainers
+	}
 	expected := r.kubegresContext.Kubegres.Spec.Resources
 
 	if !r.compareResources(current, expected) {
@@ -56,7 +59,12 @@ func (r *ResourcesSpecEnforcer) CheckForSpecDifference(statefulSet *apps.Statefu
 }
 
 func (r *ResourcesSpecEnforcer) EnforceSpec(statefulSet *apps.StatefulSet) (wasSpecUpdated bool, err error) {
-	statefulSet.Spec.Template.Spec.Containers[0].Resources = r.kubegresContext.Kubegres.Spec.Resources
+	for i := range statefulSet.Spec.Template.Spec.Containers {
+		statefulSet.Spec.Template.Spec.Containers[i].Resources = r.kubegresContext.Kubegres.Spec.Resources
+	}
+	for i := range statefulSet.Spec.Template.Spec.InitContainers {
+		statefulSet.Spec.Template.Spec.InitContainers[i].Resources = r.kubegresContext.Kubegres.Spec.Resources
+	}
 	return true, nil
 }
 

--- a/controllers/spec/template/ResourcesCreatorFromTemplate.go
+++ b/controllers/spec/template/ResourcesCreatorFromTemplate.go
@@ -132,6 +132,7 @@ func (r *ResourcesCreatorFromTemplate) CreateReplicaStatefulSet(statefulSetInsta
 	initContainer.Env[1].ValueFrom = r.getEnvVar(ctx.EnvVarNameOfPostgresReplicationUserPsw).ValueFrom
 	initContainer.Env[2].Value = postgresSpec.Database.VolumeMount + "/" + ctx.DefaultDatabaseFolder
 	initContainer.VolumeMounts[0].MountPath = postgresSpec.Database.VolumeMount
+	initContainer.Resources = postgresSpec.Resources
 
 	return statefulSetTemplate, nil
 }

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2461,7 +2461,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v15
+        image: tetrate/kubegres:blackrock-fix
         livenessProbe:
           httpGet:
             path: /healthz

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2461,7 +2461,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:blackrock-fix
+        image: tetrate/kubegres:blackrock-fix-in-load-tmpl
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test/spec_replica_test.go
+++ b/test/spec_replica_test.go
@@ -22,12 +22,14 @@ package test
 
 import (
 	"log"
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	postgresv1 "reactive-tech.io/kubegres/api/v1"
 	"reactive-tech.io/kubegres/test/resourceConfigs"
 	"reactive-tech.io/kubegres/test/util"
@@ -127,7 +129,24 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("group:5"), func() {
 
 			log.Print("END OF: Test 'GIVEN new Kubegres is created with spec 'replica' set to 2'")
 		})
+	})
 
+	Context("GIVEN new Kubegres is created with spec 'replica' set to 2 and 'resources' set to a value", func() {
+
+		It("THEN replica should be created with and resources are set for both initContainer and container", func() {
+
+			log.Print("START OF: Test 'GIVEN new Kubegres is created with spec 'replica' set to 2 and 'resources' set to a value'")
+
+			resources := test.givenResources("2", "2Gi", "1", "1Gi")
+
+			test.givenNewKubegresSpecWithReplicasAndResources(2, resources)
+			test.whenKubegresIsCreated()
+
+			test.thenPodsStatesShouldBe(1, 1)
+
+			test.replicaShouldHaveResourcesSet(resources)
+
+		})
 	})
 
 	Context("GIVEN new Kubegres is created with spec 'replica' set to 3 and then it is updated to different values", func() {
@@ -230,6 +249,25 @@ func (r *SpecReplicaTest) givenNewKubegresSpecIsSetTo(specNbreReplicas int32) {
 	r.kubegresResource.Spec.Replicas = &specNbreReplicas
 }
 
+func (r *SpecReplicaTest) givenNewKubegresSpecWithReplicasAndResources(specNbreReplicas int32, resources corev1.ResourceRequirements) {
+	r.kubegresResource = resourceConfigs.LoadKubegresYaml()
+	r.kubegresResource.Spec.Replicas = &specNbreReplicas
+	r.kubegresResource.Spec.Resources = resources
+}
+
+func (r *SpecReplicaTest) givenResources(cpuLimit, memLimit, cpuReq, memReq string) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"cpu":    resource.MustParse(cpuLimit),
+			"memory": resource.MustParse(memLimit),
+		},
+		Requests: corev1.ResourceList{
+			"cpu":    resource.MustParse(cpuReq),
+			"memory": resource.MustParse(memReq),
+		},
+	}
+}
+
 func (r *SpecReplicaTest) givenExistingKubegresSpecIsSetTo(specNbreReplicas int32) {
 	var err error
 	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
@@ -253,7 +291,7 @@ func (r *SpecReplicaTest) whenKubernetesIsUpdated() {
 
 func (r *SpecReplicaTest) thenErrorEventShouldBeLogged() {
 	expectedErrorEvent := util.EventRecord{
-		Eventtype: v12.EventTypeWarning,
+		Eventtype: corev1.EventTypeWarning,
 		Reason:    "SpecCheckErr",
 		Message:   "In the Resources Spec the value of 'spec.replicas' is undefined. Please set a value otherwise this operator cannot work correctly.",
 	}
@@ -301,4 +339,32 @@ func (r *SpecReplicaTest) thenDeployedKubegresSpecShouldBeSetTo(specNbreReplicas
 	}
 
 	Expect(*r.kubegresResource.Spec.Replicas).Should(Equal(specNbreReplicas))
+}
+
+func (r *SpecReplicaTest) replicaShouldHaveResourcesSet(resources corev1.ResourceRequirements) {
+
+	Eventually(func() bool {
+		pods, err := r.resourceRetriever.GetKubegresResources()
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.Println("ERROR while retrieving Kubegres pods")
+			return false
+		}
+
+		for _, kubegresResource := range pods.Resources {
+			for _, initContainer := range kubegresResource.StatefulSet.Spec.Template.Spec.InitContainers {
+				if !reflect.DeepEqual(initContainer.Resources, resources) {
+					log.Printf("InitContainer resources are not equal. got: %v want: %v", initContainer.Resources, resources)
+					return false
+				}
+			}
+			for _, container := range kubegresResource.StatefulSet.Spec.Template.Spec.Containers {
+				if !reflect.DeepEqual(container.Resources, resources) {
+					log.Printf("Container resources are not equal. got: %v want: %v", container.Resources, resources)
+					return false
+				}
+			}
+		}
+		return true
+
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }

--- a/test/spec_replica_test.go
+++ b/test/spec_replica_test.go
@@ -146,7 +146,27 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("group:5"), func() {
 
 			test.replicaShouldHaveResourcesSet(resources)
 
+			test.keepCreatedResourcesForNextTest = true
+
 		})
+
+		It("THEN existing Kubegres is updated with 'resources' the 'resources' should be updated for both initContainer and container", func() {
+			log.Print("START OF: Test 'THEN existing Kubegres is updated with 'resources' the 'resources' should be updated for both initContainer and container'")
+
+			resources := test.givenResources("4", "4Gi", "2", "2Gi")
+			test.givenExistingKubegresSpecResourcesIsSetTo(resources)
+
+			test.whenKubernetesIsUpdated()
+
+			test.thenPodsStatesShouldBe(1, 1)
+
+			test.replicaShouldHaveResourcesSet(resources)
+
+			test.keepCreatedResourcesForNextTest = true
+
+			log.Print("END OF: Test 'THEN existing Kubegres is updated with 'resources' the 'resources' should be updated for both initContainer and container'")
+		})
+
 	})
 
 	Context("GIVEN new Kubegres is created with spec 'replica' set to 3 and then it is updated to different values", func() {
@@ -367,4 +387,18 @@ func (r *SpecReplicaTest) replicaShouldHaveResourcesSet(resources corev1.Resourc
 		return true
 
 	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
+}
+
+func (r *SpecReplicaTest) givenExistingKubegresSpecResourcesIsSetTo(resources corev1.ResourceRequirements) {
+
+	var err error
+	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+
+	if err != nil {
+		log.Println("Error while getting Kubegres resource : ", err)
+		Expect(err).Should(Succeed())
+		return
+	}
+
+	r.kubegresResource.Spec.Resources = resources
 }

--- a/test/spec_resource_test.go
+++ b/test/spec_resource_test.go
@@ -223,12 +223,21 @@ func (r *SpecResourceTest) thenStatefulSetStatesShouldBe(expectedResources v12.R
 		}
 
 		for _, resource := range kubegresResources.Resources {
-			currentResources := resource.StatefulSet.Spec.Template.Spec.Containers[0].Resources
-
-			if !reflect.DeepEqual(currentResources, expectedResources) {
-				log.Println("StatefulSet '" + resource.StatefulSet.Name + "' doesn't have the expected spec 'resources': " + expectedResources.String() + " " +
-					"Current value: '" + currentResources.String() + "'. Waiting...")
-				return false
+			for i := range resource.StatefulSet.Spec.Template.Spec.Containers {
+				currentResources := resource.StatefulSet.Spec.Template.Spec.Containers[i].Resources
+				if !reflect.DeepEqual(currentResources, expectedResources) {
+					log.Println("StatefulSet '" + resource.StatefulSet.Name + "' doesn't have the expected spec 'resources': " + expectedResources.String() + " " +
+						"Current value: '" + currentResources.String() + "'. Waiting...")
+					return false
+				}
+			}
+			for i := range resource.StatefulSet.Spec.Template.Spec.InitContainers {
+				currentResources := resource.StatefulSet.Spec.Template.Spec.InitContainers[i].Resources
+				if !reflect.DeepEqual(currentResources, expectedResources) {
+					log.Println("StatefulSet '" + resource.StatefulSet.Name + "' doesn't have the expected spec 'resources': " + expectedResources.String() + " " +
+						"Current value: '" + currentResources.String() + "'. Waiting...")
+					return false
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/tetrateio/tetrate/issues/24931