### PR TITLE
bump go to 1.24.5 to fix CVE-2025-4673 and CVE-2025-0913

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
| Severity | Image              | CVE            | Package | Fix                          | Remaining SLA |
|----------|-------------------|----------------|---------|-------------------------------|----------------|
| HIGH   | kubegres:v1.16.0-t | CVE-2025-22874  | stdlib  | v1.24.2 → 1.24.4    | 1 days        |
| MEDIUM   | kubegres:v1.16.0-t | CVE-2025-4673  | stdlib  | v1.24.2 → 1.23.10, 1.24.4    | 62 days        |
| MEDIUM   | kubegres:v1.16.0-t | CVE-2025-0913  | stdlib  | v1.24.2 → 1.23.10, 1.24.4    | 71 days        |
