### PR TITLE
Bumps go to `1.24.6`, prepare for `v1.16.0-tetrate-v21` release

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v20
+  newTag: v1.16.0-tetrate-v21

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -4738,7 +4738,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v20
+        image: tetrate/kubegres:v1.16.0-tetrate-v21
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
required to fix high cve: [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907)