### PR TITLE
fix(replicationSlots): check if replication slots exist when computing required number of replicas

### DIFF
--- a/controllers/cleanupreconciler.go
+++ b/controllers/cleanupreconciler.go
@@ -151,8 +151,6 @@ func (r *CleanupReplicationSlotsReconciler) Reconcile(ctx context.Context, reque
 		return reconcile.Result{}, nil
 	}
 
-	r.Logger.Info("Starting replication slots cleanup", "kubegres", kubegres.Name)
-
 	wrappedLogger := log.LogWrapper{Kubegres: &kubegres, Logger: r.Logger, Recorder: r.Recorder}
 
 	kubegresContext := kubegresCtx.KubegresContext{
@@ -181,6 +179,8 @@ func (r *CleanupReplicationSlotsReconciler) Reconcile(ctx context.Context, reque
 	if r.cleanupRoutinesHandler.HasActiveRoutine(ctrlclient.ObjectKeyFromObject(&kubegres), r.getSettings(kubegres)) {
 		return reconcile.Result{}, nil
 	}
+
+	r.Logger.Info("Starting replication slots cleanup", "kubegres", kubegres.Name)
 	r.cleanupRoutinesHandler.startCleanup(
 		ctrlclient.ObjectKeyFromObject(&kubegres),
 		r.getSettings(kubegres),

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
@@ -583,10 +583,10 @@ func (r *ReplicaDbCountSpecEnforcer) hasReplicationSlotsEnabled(statefulSet stat
 		for _, envVar := range container.Env {
 			if envVar.Name == kubegresCtx.EnvVarReplicationSlotName && envVar.Value != "" {
 				// Also check if the replication slot actually exist in the database.
-				// If it does not, treat it as if replication slots are not enabled, so we'll trigger a rollout of the 
+				// If it does not, treat it as if replication slots are not enabled, so we'll trigger a rollout of the
 				// current replica.
 				// This could happen after a failover when the primary changes and the new primary does not have
-				// replication slots created for the alread existing replicas.
+				// replication slots created for the already existing replicas.
 				// Causing the rollout of the replicas will make all of them to be registered in the new primary.
 				_, err := r.replicationSlotsCreateDeleter.GetFor(&statefulSet.StatefulSet)
 				if errors.Is(err, errNotFound) {

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
@@ -582,10 +582,12 @@ func (r *ReplicaDbCountSpecEnforcer) hasReplicationSlotsEnabled(statefulSet stat
 	for _, container := range statefulSet.StatefulSet.Spec.Template.Spec.Containers {
 		for _, envVar := range container.Env {
 			if envVar.Name == kubegresCtx.EnvVarReplicationSlotName && envVar.Value != "" {
-				// we also need to check if the replication slot actually exist in the database
-				// if it does not exist, we should treat it as if replication slots are not enabled.
+				// Also check if the replication slot actually exist in the database.
+				// If it does not, treat it as if replication slots are not enabled, so we'll trigger a rollout of the 
+				// current replica.
 				// This could happen after a failover when the primary changes and the new primary does not have
-				// replication slots created for existing replicas.
+				// replication slots created for the alread existing replicas.
+				// Causing the rollout of the replicas will make all of them to be registered in the new primary.
 				_, err := r.replicationSlotsCreateDeleter.GetFor(&statefulSet.StatefulSet)
 				if errors.Is(err, errNotFound) {
 					return false

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
@@ -38,6 +38,7 @@ import (
 	"reactive-tech.io/kubegres/controllers/spec/template"
 	"reactive-tech.io/kubegres/controllers/states"
 	"reactive-tech.io/kubegres/controllers/states/statefulset"
+	"reactive-tech.io/kubegres/internal/replicationslot"
 	replicationSlotRepo "reactive-tech.io/kubegres/internal/replicationslot/repo"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -51,16 +52,21 @@ type ReplicaDbCountSpecEnforcer struct {
 }
 
 type replicationSlotsCreateDeleter interface {
-	Create(*v1.StatefulSet) (*v1.StatefulSet, error)
-	Delete(*v1.StatefulSet) error
+	CreateFor(*v1.StatefulSet) (*v1.StatefulSet, error)
+	DeleteFor(*v1.StatefulSet) error
+	GetFor(*v1.StatefulSet) (replicationslot.ReplicationSlot, error)
 }
 
 type noopReplicationSlotsCreateDeleter struct{}
 
-func (n noopReplicationSlotsCreateDeleter) Create(ss *v1.StatefulSet) (*v1.StatefulSet, error) {
+func (n noopReplicationSlotsCreateDeleter) GetFor(_ *v1.StatefulSet) (replicationslot.ReplicationSlot, error) {
+	return replicationslot.ReplicationSlot{}, nil
+}
+
+func (n noopReplicationSlotsCreateDeleter) CreateFor(ss *v1.StatefulSet) (*v1.StatefulSet, error) {
 	return ss, nil
 }
-func (n noopReplicationSlotsCreateDeleter) Delete(*v1.StatefulSet) error { return nil }
+func (n noopReplicationSlotsCreateDeleter) DeleteFor(*v1.StatefulSet) error { return nil }
 
 func CreateReplicaDbCountSpecEnforcer(
 	kubegresContext kubegresCtx.KubegresContext,
@@ -102,7 +108,24 @@ type simpleReplicationSlotCreateDeleter struct {
 	clusterName     string
 }
 
-func (r *simpleReplicationSlotCreateDeleter) Create(statefulSet *v1.StatefulSet) (*v1.StatefulSet, error) {
+var errNotFound = errors.New("not found")
+
+func (r *simpleReplicationSlotCreateDeleter) GetFor(set *v1.StatefulSet) (replicationslot.ReplicationSlot, error) {
+	replicationSlotName, err := buildReplicationSlotName(r.kubegresContext.Kubegres.GetName(), r.clusterName, set.GetName(), r.kubegresContext.ClusterRole())
+	if err != nil {
+		return replicationslot.ReplicationSlot{}, fmt.Errorf("replication slot name: %v: %w", ctrlclient.ObjectKeyFromObject(set), err)
+	}
+	replicationSlot, err := r.repo.GetSlot(r.kubegresContext.Ctx, replicationSlotName)
+	if err != nil {
+		if errors.Is(err, replicationSlotRepo.ErrNotFound) {
+			return replicationslot.ReplicationSlot{}, errNotFound
+		}
+		return replicationslot.ReplicationSlot{}, err
+	}
+	return replicationSlot, nil
+}
+
+func (r *simpleReplicationSlotCreateDeleter) CreateFor(statefulSet *v1.StatefulSet) (*v1.StatefulSet, error) {
 	replicationSlotName, err := buildReplicationSlotName(r.kubegresContext.Kubegres.GetName(), r.clusterName, statefulSet.GetName(), r.kubegresContext.ClusterRole())
 	objKey := ctrlclient.ObjectKeyFromObject(statefulSet)
 	if err != nil {
@@ -111,6 +134,10 @@ func (r *simpleReplicationSlotCreateDeleter) Create(statefulSet *v1.StatefulSet)
 	}
 	slot, err := r.repo.CreateSlot(r.kubegresContext.Ctx, replicationSlotName)
 	if err != nil {
+		if errors.Is(err, replicationSlotRepo.ErrAlreadyExist) {
+			r.kubegresContext.Log.WarningEvent("ReplicationSlotCreate", fmt.Sprintf("Replication slot '%s' for statefulSet '%s' already exists, skipping creation.", replicationSlotName, statefulSet.GetName()))
+			return nil, nil
+		}
 		r.kubegresContext.Log.ErrorEvent("ReplicationSlotCreate", fmt.Errorf("replication slot: %v for statefulSet: %v: %w", slot, objKey, err), "Failed to create replication slot")
 		return nil, err
 	}
@@ -155,7 +182,7 @@ func buildReplicationSlotName(kubegresName, clusterName, statefulSetName string,
 	return replicationSlotName, nil
 }
 
-func (r *simpleReplicationSlotCreateDeleter) Delete(statefulSet *v1.StatefulSet) error {
+func (r *simpleReplicationSlotCreateDeleter) DeleteFor(statefulSet *v1.StatefulSet) error {
 	replicationSlotName, err := buildReplicationSlotName(r.kubegresContext.Kubegres.GetName(), r.clusterName, statefulSet.GetName(), r.kubegresContext.ClusterRole())
 	objKey := ctrlclient.ObjectKeyFromObject(statefulSet)
 	if err != nil {
@@ -419,7 +446,7 @@ func (r *ReplicaDbCountSpecEnforcer) deployReplicaStatefulSet() error {
 		return err
 	}
 
-	updatedStatefulSet, err := r.replicationSlotsCreateDeleter.Create(&replicaStatefulSet)
+	updatedStatefulSet, err := r.replicationSlotsCreateDeleter.CreateFor(&replicaStatefulSet)
 	if err != nil {
 		r.kubegresContext.Log.ErrorEvent("ReplicaStatefulSetReplicationSlotCreationErr", err, "Error while creating replication slot for the Replica StatefulSet.", "Replica name", replicaStatefulSet.Name)
 		r.blockingOperation.RemoveActiveOperation()
@@ -495,11 +522,12 @@ func (r *ReplicaDbCountSpecEnforcer) undeployReplicaStatefulSets(replicaToUndepl
 		return true
 	}, func() error {
 		attempt++
-		return r.replicationSlotsCreateDeleter.Delete(&replicaToUndeploy.StatefulSet)
+		return r.replicationSlotsCreateDeleter.DeleteFor(&replicaToUndeploy.StatefulSet)
 	})
 
 	if err != nil {
 		// exhausted all attempts to delete the replication slot
+		r.blockingOperation.RemoveActiveOperation()
 		r.kubegresContext.Log.ErrorEvent("ReplicaStatefulSetReplicationSlotDeletionErr", err, "Failed to delete replication slot for the Replica StatefulSet after all attempts.", "Replica name", replicaToUndeploy.StatefulSet.Name, "Attempt", attempt)
 	}
 
@@ -554,6 +582,17 @@ func (r *ReplicaDbCountSpecEnforcer) hasReplicationSlotsEnabled(statefulSet stat
 	for _, container := range statefulSet.StatefulSet.Spec.Template.Spec.Containers {
 		for _, envVar := range container.Env {
 			if envVar.Name == kubegresCtx.EnvVarReplicationSlotName && envVar.Value != "" {
+				// we also need to check if the replication slot actually exist in the database
+				// if it does not exist, we should treat it as if replication slots are not enabled.
+				// This could happen after a failover when the primary changes and the new primary does not have
+				// replication slots created for existing replicas.
+				_, err := r.replicationSlotsCreateDeleter.GetFor(&statefulSet.StatefulSet)
+				if errors.Is(err, errNotFound) {
+					return false
+				}
+				if err != nil {
+					r.kubegresContext.Log.ErrorEvent("ReplicationSlotCheckErr", err, "Error while checking replication slot for the Replica StatefulSet.", "Replica name", statefulSet.StatefulSet.Name)
+				}
 				return true
 			}
 		}

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/failover/PrimaryToReplicaFailOver.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/failover/PrimaryToReplicaFailOver.go
@@ -216,7 +216,7 @@ func (r *PrimaryToReplicaFailOver) selectReplicaToPromote() (statefulset.Statefu
 	}
 
 	for _, statefulSetWrapper := range r.resourcesStates.StatefulSets.Replicas.All.GetAllSortedByInstanceIndex() {
-		if statefulSetWrapper.IsReady {
+		if statefulSetWrapper.IsReady && statefulSetWrapper.HaveReplicationSlotSet == r.kubegresContext.Kubegres.Spec.ReplicationSlots.Enabled {
 			return statefulSetWrapper, nil
 		}
 	}

--- a/controllers/states/statefulset/StatefulSetWrapper.go
+++ b/controllers/states/statefulset/StatefulSetWrapper.go
@@ -2,17 +2,19 @@ package statefulset
 
 import (
 	"errors"
-	"k8s.io/api/apps/v1"
 	"sort"
 	"strconv"
+
+	"k8s.io/api/apps/v1"
 )
 
 type StatefulSetWrapper struct {
-	IsDeployed    bool
-	IsReady       bool
-	InstanceIndex int32
-	StatefulSet   v1.StatefulSet
-	Pod           PodWrapper
+	IsDeployed             bool
+	IsReady                bool
+	InstanceIndex          int32
+	StatefulSet            v1.StatefulSet
+	Pod                    PodWrapper
+	HaveReplicationSlotSet bool
 }
 
 type StatefulSetWrappers struct {

--- a/controllers/states/statefulset/StatefulSetsStates.go
+++ b/controllers/states/statefulset/StatefulSetsStates.go
@@ -22,11 +22,12 @@ package statefulset
 
 import (
 	"errors"
+	"strconv"
+
 	apps "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"reactive-tech.io/kubegres/controllers/ctx"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 type StatefulSetsStates struct {
@@ -83,6 +84,7 @@ func (r *StatefulSetsStates) createAndAppendStatefulSetStates(statefulSet apps.S
 	statefulSetWrapper := StatefulSetWrapper{}
 	statefulSetWrapper.IsDeployed = true
 	statefulSetWrapper.IsReady = statefulSet.Status.ReadyReplicas > 0
+	statefulSetWrapper.HaveReplicationSlotSet = r.haveReplicationSlotSet(statefulSet)
 	statefulSetWrapper.StatefulSet = statefulSet
 
 	instanceIndex, err := r.getInstanceIndexFromSpec(statefulSet)
@@ -128,7 +130,7 @@ func (r *StatefulSetsStates) addReplicaStatefulSetStates(statefulSetWrapper Stat
 	r.Replicas.NbreDeployed++
 	r.Replicas.All.Add(statefulSetWrapper)
 
-	if statefulSetWrapper.IsReady {
+	if statefulSetWrapper.IsReady && r.kubegresContext.Kubegres.Spec.ReplicationSlots.Enabled == statefulSetWrapper.HaveReplicationSlotSet {
 		r.Replicas.NbreReady++
 	}
 }
@@ -174,4 +176,15 @@ func (r *StatefulSetsStates) getInstanceIndexFromSpec(statefulSet apps.StatefulS
 		return 0, err
 	}
 	return int32(instanceIndex), nil
+}
+
+func (r *StatefulSetsStates) haveReplicationSlotSet(set apps.StatefulSet) bool {
+	for _, container := range set.Spec.Template.Spec.Containers {
+		for _, envVar := range container.Env {
+			if envVar.Name == ctx.EnvVarReplicationSlotName && envVar.Value != "" {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -139,6 +139,9 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			test.GivenUserAddedInPrimaryDb()
 			expectedNbreUsers++
 
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
+
 			// First failover
 
 			test.whenPrimaryIsDeleted()
@@ -195,6 +198,9 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 			test.GivenUserAddedInPrimaryDb()
 			expectedNbreUsers++
+
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
 
 			// First failover
 			test.whenPrimaryIsDeleted()

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -201,8 +201,7 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			// First failover
 			test.whenPrimaryIsDeleted()
 
-			test.thenPodsStatesShouldBe(1, 2+2) // There should be 2 replicas left + wait for at least 2 new replicas to be created because the old replicas don't have replication slots
-			test.thenPodsStatesShouldBe(1, 3)   // after new replicas are created, wait for old replicas to be deleted
+			test.thenPodsStatesShouldBe(1, 3)
 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
@@ -217,8 +216,7 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 			test.whenPrimaryIsDeleted()
 
-			test.thenPodsStatesShouldBe(1, 2+2) // There should be 2 replicas left + wait for at least 2 new replicas to be created because the old replicas don't have replication slots
-			test.thenPodsStatesShouldBe(1, 3)   // after new replicas are created, wait for old replicas to be deleted
+			test.thenPodsStatesShouldBe(1, 3)
 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -210,17 +210,11 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
 
-			log.Println("waiting ")
-			//time.Sleep(10 * time.Minute)
-
 			// Second failover
 
 			test.whenPrimaryIsDeleted()
 
 			test.thenPodsStatesShouldBe(1, 3)
-
-			log.Println("waiting ")
-			//time.Sleep(10 * time.Minute)
 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -85,7 +85,6 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 	Context("GIVEN Kubegres with 1 primary and no replicas AND that primary is deleted including its associated PVC", func() {
 
 		It("THEN the primary should be automatically re-created and a new PVC should be associated to the new primary", func() {
-			Skip("temp")
 
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and no replicas AND that primary is deleted including its associated PVC'")
 
@@ -124,7 +123,6 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 		It("THEN the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
 
-			Skip("temp")
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 1 replicas AND primary is deleted'")
 
 			test.givenNewKubegresSpecIsSetTo(2)
@@ -236,7 +234,6 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 		})
 
 		It("THEN the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
-			Skip("temp")
 
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 2 replicas using custom-configs map AND primary is deleted'")
 

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -175,10 +175,6 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			log.Print("END OF: Test 'GIVEN Kubegres with 1 primary and 1 replicas AND primary is deleted'")
 		})
 
-	})
-
-	Context("GIVEN Kubegres with 1 primary and 2 replicas using custom-configs map AND primary is deleted", func() {
-
 		It("THEN when Replication Slots are enabled, the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
 
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 2 replicas with Replication Slots enabled AND primary is deleted'")
@@ -205,7 +201,8 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			// First failover
 			test.whenPrimaryIsDeleted()
 
-			test.thenPodsStatesShouldBe(1, 3)
+			test.thenPodsStatesShouldBe(1, 2+2) // There should be 2 replicas left + wait for at least 2 new replicas to be created because the old replicas don't have replication slots
+			test.thenPodsStatesShouldBe(1, 3)   // after new replicas are created, wait for old replicas to be deleted
 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
@@ -220,7 +217,8 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 			test.whenPrimaryIsDeleted()
 
-			test.thenPodsStatesShouldBe(1, 3)
+			test.thenPodsStatesShouldBe(1, 2+2) // There should be 2 replicas left + wait for at least 2 new replicas to be created because the old replicas don't have replication slots
+			test.thenPodsStatesShouldBe(1, 3)   // after new replicas are created, wait for old replicas to be deleted
 
 			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
@@ -232,6 +230,10 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
 
 		})
+
+	})
+
+	Context("GIVEN Kubegres with 1 primary and 2 replicas using custom-configs map AND primary is deleted", func() {
 
 		It("THEN the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
 

--- a/test/primary_failure_and_recovery_test.go
+++ b/test/primary_failure_and_recovery_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 	Context("GIVEN Kubegres with 1 primary and no replicas AND that primary is deleted including its associated PVC", func() {
 
 		It("THEN the primary should be automatically re-created and a new PVC should be associated to the new primary", func() {
+			Skip("temp")
 
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and no replicas AND that primary is deleted including its associated PVC'")
 
@@ -123,6 +124,7 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 		It("THEN the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
 
+			Skip("temp")
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 1 replicas AND primary is deleted'")
 
 			test.givenNewKubegresSpecIsSetTo(2)
@@ -171,11 +173,70 @@ var _ = Describe("Primary instances is not available, checking recovery works", 
 
 			log.Print("END OF: Test 'GIVEN Kubegres with 1 primary and 1 replicas AND primary is deleted'")
 		})
+
 	})
 
 	Context("GIVEN Kubegres with 1 primary and 2 replicas using custom-configs map AND primary is deleted", func() {
 
+		It("THEN when Replication Slots are enabled, the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
+
+			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 2 replicas with Replication Slots enabled AND primary is deleted'")
+
+			var rs = &postgresv1.ReplicationSlots{
+				Enabled: true,
+			}
+			test.givenNewKubegresReplicationSlotsAreSetTo(rs, 4)
+
+			test.whenKubegresIsCreated()
+
+			test.thenPodsStatesShouldBe(1, 3)
+			expectedNbreUsers := 0
+
+			test.GivenUserAddedInPrimaryDb()
+			expectedNbreUsers++
+
+			test.GivenUserAddedInPrimaryDb()
+			expectedNbreUsers++
+
+			// First failover
+			test.whenPrimaryIsDeleted()
+
+			test.thenPodsStatesShouldBe(1, 3)
+
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
+
+			test.GivenUserAddedInPrimaryDb()
+			expectedNbreUsers++
+
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
+
+			log.Println("waiting ")
+			//time.Sleep(10 * time.Minute)
+
+			// Second failover
+
+			test.whenPrimaryIsDeleted()
+
+			test.thenPodsStatesShouldBe(1, 3)
+
+			log.Println("waiting ")
+			//time.Sleep(10 * time.Minute)
+
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
+
+			test.GivenUserAddedInPrimaryDb()
+			expectedNbreUsers++
+
+			test.ThenPrimaryDbContainsExpectedNbreUsers(expectedNbreUsers)
+			test.ThenReplicaDbContainsExpectedNbreUsers(expectedNbreUsers)
+
+		})
+
 		It("THEN the failover should take place with a replica becoming primary AND a new replica created AND existing data available, twice", func() {
+			Skip("temp")
 
 			log.Print("START OF: Test 'GIVEN Kubegres with 1 primary and 2 replicas using custom-configs map AND primary is deleted'")
 
@@ -390,4 +451,11 @@ func (r *PrimaryFailureAndRecoveryTest) ThenReplicaDbContainsExpectedNbreUsers(e
 		return true
 
 	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
+}
+
+func (r *PrimaryFailureAndRecoveryTest) givenNewKubegresReplicationSlotsAreSetTo(rs *postgresv1.ReplicationSlots, replicas int) {
+	r.kubegresResource = resourceConfigs.LoadKubegresYaml()
+	i := int32(replicas)
+	r.kubegresResource.Spec.Replicas = &i
+	r.kubegresResource.Spec.ReplicationSlots = *rs
 }

--- a/test/resourceConfigs/ConfigForTest.go
+++ b/test/resourceConfigs/ConfigForTest.go
@@ -23,8 +23,8 @@ package resourceConfigs
 import "time"
 
 const (
-	TestTimeout            = time.Second * 240
-	TestRetryInterval      = time.Second * 5
+	TestTimeout            = 240 * time.Second
+	TestRetryInterval      = 2 * time.Second
 	DefaultNamespace       = "default"
 	PrimaryReplicationRole = "primary"
 	DbPort                 = 5432

--- a/test/standby_test.go
+++ b/test/standby_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
 		Expect(k8sClientTest).ToNot(BeNil())
 		test.standbyDBQueryTestCases = testcases.InitDbQueryTestCasesWithConnections(
-			util.InitExternalDbConnectionDbUtil(test.resourceCreator, resourceConfigs.ServiceToSqlQueryExternalDbNodePort, k8sClientTest),
+			util.InitExternalDbConnectionDbUtil(test.resourceCreator, resourceConfigs.ServiceToSqlQueryExternalDbNodePort, k8sClientTest, false),
 			util.InitDbConnectionDbUtil(test.resourceCreator, resourceConfigs.KubegresResourceName, resourceConfigs.ServiceToSqlQueryReplicaDbNodePort, false, k8sClientTest),
 		)
 		test.activeDBQueryTestCases = testcases.InitDbQueryTestCasesWithConnections(
@@ -265,7 +265,7 @@ var _ = Describe("Setting Kubegres spec 'replica' with replication slots", Label
 		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
 		Expect(k8sClientTest).ToNot(BeNil())
 		test.standbyDBQueryTestCases = testcases.InitDbQueryTestCasesWithConnections(
-			util.InitExternalDbConnectionDbUtil(test.resourceCreator, resourceConfigs.ServiceToSqlQueryExternalDbNodePort, k8sClientTest),
+			util.InitExternalDbConnectionDbUtil(test.resourceCreator, resourceConfigs.ServiceToSqlQueryExternalDbNodePort, k8sClientTest, true),
 			util.InitDbConnectionDbUtil(test.resourceCreator, resourceConfigs.KubegresResourceName, resourceConfigs.ServiceToSqlQueryReplicaDbNodePort, false, k8sClientTest),
 		)
 	})

--- a/test/standby_test.go
+++ b/test/standby_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsCreated()
 
-			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -89,7 +89,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsUpdated()
 
-			test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -107,7 +107,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsUpdated()
 
-			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -130,7 +130,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsCreated()
 
-			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -139,7 +139,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsUpdated()
 
-			test.thenPodsStatesShouldBe("external-postgres.default.svc.cluster.local", 0, 1, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres.default.svc.cluster.local", 0, 1, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -164,7 +164,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 			test.whenKubegresIsCreated()
 
-			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue)
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
 
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -188,7 +188,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 				test.whenKubegresIsCreated()
 
-				test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue)
+				test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
 
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -206,7 +206,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 				test.whenKubegresIsUpdated()
 
-				test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue)
+				test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue, false)
 
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -224,7 +224,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 				test.whenKubegresIsUpdated()
 
-				test.thenPodsStatesShouldBe("my-kubegres", 1, 1, template.LabelModelActiveValue)
+				test.thenPodsStatesShouldBe("my-kubegres", 1, 1, template.LabelModelActiveValue, false)
 
 				test.activeDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 				test.activeDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -243,7 +243,7 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 
 				test.whenKubegresIsUpdated()
 
-				test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue)
+				test.thenPodsStatesShouldBe("external-postgres", 0, 2, template.LabelModelStandbyValue, false)
 
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
 				test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
@@ -253,6 +253,94 @@ var _ = Describe("Setting Kubegres spec 'replica'", Label("standby"), func() {
 			})
 
 		})
+})
+
+var _ = Describe("Setting Kubegres spec 'replica' with replication slots", Label("standby"), func() {
+
+	var test = StandByTest{}
+
+	BeforeEach(func() {
+		namespace := resourceConfigs.DefaultNamespace
+		test.resourceRetriever = util.CreateTestResourceRetriever(k8sClientTest, namespace)
+		test.resourceCreator = util.CreateTestResourceCreator(k8sClientTest, test.resourceRetriever, namespace)
+		Expect(k8sClientTest).ToNot(BeNil())
+		test.standbyDBQueryTestCases = testcases.InitDbQueryTestCasesWithConnections(
+			util.InitExternalDbConnectionDbUtil(test.resourceCreator, resourceConfigs.ServiceToSqlQueryExternalDbNodePort, k8sClientTest),
+			util.InitDbConnectionDbUtil(test.resourceCreator, resourceConfigs.KubegresResourceName, resourceConfigs.ServiceToSqlQueryReplicaDbNodePort, false, k8sClientTest),
+		)
+	})
+
+	AfterEach(func() {
+		if !test.keepCreatedResourcesForNextTest {
+			test.resourceCreator.DeleteAllTestResources()
+		} else {
+			test.keepCreatedResourcesForNextTest = false
+		}
+	})
+	Context("GIVEN replication slots are enabled in the standby spec", func() {
+
+		It("THEN replica set to 1 should be running and replicating data from external postgres ", func() {
+
+			log.Print("START OF: Test 'GIVEN replica set to 1 should be running and replicating data from external postgres")
+
+			test.givenNewExternalPostgresIsCreatedAndReady()
+
+			test.givenNewKubegresSpecIsStandbySetToTrueAndPrimaryEndpointSetToExternalPostgres()
+
+			test.whenKubegresIsCreated()
+
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, false)
+
+			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
+			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
+
+			test.keepCreatedResourcesForNextTest = true
+
+			log.Print("END OF: Test 'replica set to 1 should be running and replicating data from external postgres")
+		})
+
+		It("THEN replication slots should be created for each replica", func() {
+			log.Print("START OF: Test 'GIVEN replication slots are enabled in the standby spec'")
+
+			test.givenExistingKubegresSpecReplicationSlotsIsSetTo(postgresv1.ReplicationSlots{
+				Enabled:        true,
+				DisableCleanup: true,
+			})
+			test.whenKubegresIsUpdated()
+
+			test.thenPodsStatesShouldBe("external-postgres", 0, 1, template.LabelModelStandbyValue, true)
+			test.standbyDBQueryTestCases.ThenWeCanSqlQueryPrimaryDb()
+			test.standbyDBQueryTestCases.ThenWeCanSqlQueryReplicaDb()
+
+			Eventually(func() bool {
+				replicationSlots := test.standbyDBQueryTestCases.GetReplicationSlots()
+				if len(replicationSlots) != 1 {
+					log.Printf("Expected 1 replication slots, but got %d. Waiting...\n", len(replicationSlots))
+					return false
+				}
+				for _, slot := range replicationSlots {
+					if !slot.Active {
+						log.Printf("Replication slot '%s' is not active. Waiting...\n", slot.Name)
+						return false
+					}
+				}
+				return true
+			})
+
+			test.keepCreatedResourcesForNextTest = true
+		})
+
+		It("THEN 'standby.enabled' set to false should promote the replica to be primary", func() {
+			log.Print("START OF: Test 'GIVEN 'standby.enabled' set to false should promote the replica to be primary'")
+
+			test.givenExistingKubegresSpecStandbyEnabledIsSetTo(false)
+			test.whenKubegresIsUpdated()
+
+			test.thenPodsStatesShouldBe("my-kubegres", 1, 0, template.LabelModelActiveValue, false)
+		})
+
+	})
+
 })
 
 type StandByTest struct {
@@ -372,7 +460,7 @@ func (r *StandByTest) thenErrorEventShouldBeLogged() {
 	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }
 
-func (r *StandByTest) thenPodsStatesShouldBe(primaryEndpoint string, nbrePrimary, nbreReplicas int, labelModeValue string) bool {
+func (r *StandByTest) thenPodsStatesShouldBe(primaryEndpoint string, nbrePrimary, nbreReplicas int, labelModeValue string, wantPodsWithReplicaitonSlots bool) bool {
 	return Eventually(func() bool {
 
 		pods, err := r.resourceRetriever.GetKubegresResources()
@@ -381,7 +469,19 @@ func (r *StandByTest) thenPodsStatesShouldBe(primaryEndpoint string, nbrePrimary
 			return false
 		}
 
+		var haveReplicationSlotsEnvVar bool
 		for _, resource := range pods.Resources {
+			for _, container := range resource.Pod.Resource.Spec.Containers {
+				for _, envVar := range container.Env {
+					if envVar.Name == ctx.EnvVarReplicationSlotName {
+						haveReplicationSlotsEnvVar = true
+					}
+				}
+			}
+			if !resource.IsPrimary && wantPodsWithReplicaitonSlots != haveReplicationSlotsEnvVar {
+				return false
+			}
+
 			if resource.Pod.Metadata.Labels[template.LabelModeKey] != labelModeValue {
 				log.Println("Pod '" + resource.Pod.Name + "' doesn't have the expected label " + template.LabelModeKey + "=" + labelModeValue + ". Waiting...")
 				return false
@@ -476,4 +576,17 @@ func (r *StandByTest) thenCronJobExistsWithSpec(expectedConfigMapName,
 		return true
 
 	}, time.Second*10, time.Second*5).Should(BeTrue())
+}
+
+func (r *StandByTest) givenExistingKubegresSpecReplicationSlotsIsSetTo(slots postgresv1.ReplicationSlots) {
+	var err error
+	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+
+	if err != nil {
+		log.Println("Error while getting Kubegres resource : ", err)
+		Expect(err).Should(Succeed())
+		return
+	}
+	r.kubegresResource.Spec.ReplicationSlots = slots
+
 }

--- a/test/standby_test.go
+++ b/test/standby_test.go
@@ -390,42 +390,54 @@ func (r *StandByTest) givenBackupPvcIsCreated() {
 }
 
 func (r *StandByTest) givenExistingKubegresSpecIsSetTo(specNbreReplicas int32) {
-	var err error
-	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+	Eventually(func() bool {
+		var err error
+		r.kubegresResource, err = r.resourceRetriever.GetKubegres()
 
-	if err != nil {
-		log.Println("Error while getting Kubegres resource : ", err)
-		Expect(err).Should(Succeed())
-		return
-	}
+		if err != nil {
+			log.Println("Error while getting Kubegres resource : ", err)
+			Expect(err).Should(Succeed())
+			return false
+		}
 
-	r.kubegresResource.Spec.Replicas = &specNbreReplicas
+		r.kubegresResource.Spec.Replicas = &specNbreReplicas
+		return true
+
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }
 
 func (r *StandByTest) givenExistingKubegresSpecStandbyEnabledIsSetTo(enabled bool) {
-	var err error
-	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+	Eventually(func() bool {
+		var err error
+		r.kubegresResource, err = r.resourceRetriever.GetKubegres()
 
-	if err != nil {
-		log.Println("Error while getting Kubegres resource : ", err)
-		Expect(err).Should(Succeed())
-		return
-	}
+		if err != nil {
+			log.Println("Error while getting Kubegres resource : ", err)
+			Expect(err).Should(Succeed())
+			return false
+		}
 
-	r.kubegresResource.Spec.Standby.Enabled = enabled
+		r.kubegresResource.Spec.Standby.Enabled = enabled
+		return true
+
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }
 
 func (r *StandByTest) givenExistingKubegresSpecIsSetToPrimaryEndpoint(newEndpoint string) {
-	var err error
-	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+	Eventually(func() bool {
+		var err error
+		r.kubegresResource, err = r.resourceRetriever.GetKubegres()
 
-	if err != nil {
-		log.Println("Error while getting Kubegres resource : ", err)
-		Expect(err).Should(Succeed())
-		return
-	}
+		if err != nil {
+			log.Println("Error while getting Kubegres resource : ", err)
+			Expect(err).Should(Succeed())
+			return false
+		}
 
-	r.kubegresResource.Spec.Standby.PrimaryEndpoint = newEndpoint
+		r.kubegresResource.Spec.Standby.PrimaryEndpoint = newEndpoint
+		return true
+
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }
 
 func (r *StandByTest) givenKubegresSpecIsSetToBackup(backupSchedule, backupPvcName, backupVolumeMount string, specNbreReplicas int32) {
@@ -579,14 +591,17 @@ func (r *StandByTest) thenCronJobExistsWithSpec(expectedConfigMapName,
 }
 
 func (r *StandByTest) givenExistingKubegresSpecReplicationSlotsIsSetTo(slots postgresv1.ReplicationSlots) {
-	var err error
-	r.kubegresResource, err = r.resourceRetriever.GetKubegres()
+	Eventually(func() bool {
+		var err error
+		r.kubegresResource, err = r.resourceRetriever.GetKubegres()
 
-	if err != nil {
-		log.Println("Error while getting Kubegres resource : ", err)
-		Expect(err).Should(Succeed())
-		return
-	}
-	r.kubegresResource.Spec.ReplicationSlots = slots
+		if err != nil {
+			log.Println("Error while getting Kubegres resource : ", err)
+			Expect(err).Should(Succeed())
+			return false
+		}
+		r.kubegresResource.Spec.ReplicationSlots = slots
+		return true
 
+	}, resourceConfigs.TestTimeout, resourceConfigs.TestRetryInterval).Should(BeTrue())
 }

--- a/test/util/DbConnectionTestUtil.go
+++ b/test/util/DbConnectionTestUtil.go
@@ -86,7 +86,7 @@ func InitExternalDbConnectionDbUtil(resourceCreator TestResourceCreator, nodePor
 		log.Fatal("Unable to create a Service on port '"+strconv.Itoa(nodePort)+"' to query external DB.", err)
 	}
 
-	return DbConnectionDbUtil{
+	db := DbConnectionDbUtil{
 		Port:             nodePort,
 		LogLabel:         "External DB",
 		IsPrimaryDb:      true,
@@ -95,6 +95,9 @@ func InitExternalDbConnectionDbUtil(resourceCreator TestResourceCreator, nodePor
 		resourceCreator:  resourceCreator,
 		k8sClient:        k8sClient,
 	}
+	db.exportNodeAddressAndPort()
+
+	return db
 }
 
 func (r *DbConnectionDbUtil) Close() {

--- a/test/util/DbConnectionTestUtil.go
+++ b/test/util/DbConnectionTestUtil.go
@@ -80,7 +80,7 @@ func InitDbConnectionDbUtil(resourceCreator TestResourceCreator, kubegresName st
 	return db
 }
 
-func InitExternalDbConnectionDbUtil(resourceCreator TestResourceCreator, nodePort int, k8sClient client.Client) DbConnectionDbUtil {
+func InitExternalDbConnectionDbUtil(resourceCreator TestResourceCreator, nodePort int, k8sClient client.Client, exportEnvVar bool) DbConnectionDbUtil {
 	serviceToQueryDb, err := resourceCreator.CreateServiceToSqlQueryExternalDb(nodePort)
 	if err != nil {
 		log.Fatal("Unable to create a Service on port '"+strconv.Itoa(nodePort)+"' to query external DB.", err)
@@ -95,7 +95,10 @@ func InitExternalDbConnectionDbUtil(resourceCreator TestResourceCreator, nodePor
 		resourceCreator:  resourceCreator,
 		k8sClient:        k8sClient,
 	}
-	db.exportNodeAddressAndPort()
+
+	if exportEnvVar {
+		db.exportNodeAddressAndPort()
+	}
 
 	return db
 }


### PR DESCRIPTION
*Previously*:
- P1 (primary) and R1 and R2 (replicas)
- P1 - contains replication slots R1 and R2
-- Failover
-- P1 is down, R1 is promoted
-- R1 have 0 replication sets
-- ReplicaStatefulSet count see only **one replica R2** - expect 2
-- ReplicaStatefulSet creates replica R3
-- We have 1 primary (R1) and 2 replicas (R2 and R3)
-- But R1 only have R3 replication slot - R2 is broken.

With this fix
- P1 (primary) and R1 and R2 (replicas)
- P1 - contains replication slots R1 and R2
-- Failover
-- P1 is down, R1 is promoted
-- R1 have 0 replication sets
-- ReplicaStatefulSet count see **zero replicas** - expect 2
-- ReplicaStatefulSet creates replica R3 and R4
-- R1 (primary) have 2 replicaiton slots (R3 and R4)
-- R2 is undeployed because it don't have replication slot