### PR TITLE
fix: standby replication slots primary endpoint

### DIFF
--- a/controllers/connection/reconciler.go
+++ b/controllers/connection/reconciler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -258,19 +257,9 @@ func updateDSNData(ctx context.Context, k8sClient client.Client, logger logr.Log
 		port = testPort
 	} else {
 		if kubegresContext.ClusterRole() == kubegresCtx.StandbyRoleName {
-			split := strings.Split(kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint, ":")
-			if len(split) != 2 {
-				err := fmt.Errorf("invalid primary endpoint format: %s", kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint)
-				wrappedLogger.Error(err, "Failed to parse primary endpoint", "connectionID", connID)
-				return nil, err
-			}
-			_, err = strconv.ParseInt(split[1], 10, 0)
-			if err != nil {
-				wrappedLogger.Error(err, "Failed to parse port from primary endpoint", "connectionID", connID)
-				return nil, fmt.Errorf("parse port from primary endpoint: %w", err)
-			}
-			port = split[1]
-			svcName = split[0]
+			// We currently don't have API to define port for primary endpoing in standby mode
+			port = "5432"
+			svcName = kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint
 		}
 
 		if kubegresContext.ClusterRole() == kubegresCtx.ActiveRoleName {

--- a/controllers/connection/reconciler.go
+++ b/controllers/connection/reconciler.go
@@ -256,27 +256,19 @@ func updateDSNData(ctx context.Context, k8sClient client.Client, logger logr.Log
 		svcName = testHost
 		port = testPort
 	} else {
-		if kubegresContext.ClusterRole() == kubegresCtx.StandbyRoleName {
-			// We currently don't have API to define port for primary endpoing in standby mode
-			port = "5432"
-			svcName = kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint
+		var resourcesStates states.ResourcesStates
+		resourcesStates, err = states.LoadResourcesStates(kubegresContext)
+		if err != nil {
+			wrappedLogger.Error(err, "Failed to load resources states", "connectionID", connID)
+			return nil, fmt.Errorf("load resources states: %w", err)
 		}
-
-		if kubegresContext.ClusterRole() == kubegresCtx.ActiveRoleName {
-			var resourcesStates states.ResourcesStates
-			resourcesStates, err = states.LoadResourcesStates(kubegresContext)
-			if err != nil {
-				wrappedLogger.Error(err, "Failed to load resources states", "connectionID", connID)
-				return nil, fmt.Errorf("load resources states: %w", err)
-			}
-			var aPort int32
-			svcName, aPort, err = resourcesStates.PrimaryConnectionDetails()
-			if err != nil {
-				wrappedLogger.Error(err, "Failed to get primary connection details", "connectionID", connID)
-				return nil, fmt.Errorf("get primary connection details: %w", err)
-			}
-			port = strconv.Itoa(int(aPort))
+		var aPort int32
+		svcName, aPort, err = resourcesStates.PrimaryConnectionDetails()
+		if err != nil {
+			wrappedLogger.Error(err, "Failed to get primary connection details", "connectionID", connID)
+			return nil, fmt.Errorf("get primary connection details: %w", err)
 		}
+		port = strconv.Itoa(int(aPort))
 	}
 
 	if svcName == "" || port == "" {

--- a/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
+++ b/controllers/spec/enforcer/resources_count_spec/statefulset/ReplicaDbCountSpecEnforcer.go
@@ -426,8 +426,9 @@ func (r *ReplicaDbCountSpecEnforcer) isReplicaDbReady(operation postgresV1.Kubeg
 	statefulSetInstanceIndex := operation.StatefulSetOperation.InstanceIndex
 	statefulSetWrapper, err := r.resourcesStates.StatefulSets.Replicas.All.GetByInstanceIndex(statefulSetInstanceIndex)
 	if err != nil {
-		r.kubegresContext.Log.InfoEvent("A replica StatefulSet's instanceIndex does not exist. As a result "+
-			"we will return false inside a blocking operation completion checker 'isReplicaDbReady()'",
+		r.kubegresContext.Log.InfoEvent("ReplicaDbInstanceNotFound",
+			"A replica StatefulSet's instanceIndex does not exist. As a result "+
+				"we will return false inside a blocking operation completion checker 'isReplicaDbReady()'",
 			"instanceIndex", statefulSetInstanceIndex)
 		return false
 	}

--- a/controllers/states/ResourcesStates.go
+++ b/controllers/states/ResourcesStates.go
@@ -22,6 +22,8 @@ package states
 
 import (
 	"errors"
+	"strconv"
+	"strings"
 
 	"reactive-tech.io/kubegres/controllers/ctx"
 	"reactive-tech.io/kubegres/controllers/states/statefulset"
@@ -99,6 +101,23 @@ func (r *ResourcesStates) loadBackUpStates() (err error) {
 }
 
 func (r *ResourcesStates) PrimaryConnectionDetails() (svcName string, port int32, err error) {
+	if r.kubegresContext.Kubegres.Spec.Standby.Enabled {
+		split := strings.Split(r.kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint, ":")
+		if len(split) != 2 {
+			return r.kubegresContext.Kubegres.Spec.Standby.PrimaryEndpoint, 5432, nil
+		}
+		svcName = split[0]
+		if split[1] == "" {
+			return "", 0, errors.New("primary endpoint port is empty")
+		}
+		var portParsed int
+		portParsed, err = strconv.Atoi(split[1])
+		if err != nil {
+			return "", 0, errors.New("primary endpoint port is not a valid number")
+		}
+		port = int32(portParsed)
+		return svcName, port, nil
+	}
 	if !r.Services.Primary.IsDeployed {
 		return "", 0, errors.New("primary service is not deployed")
 	}


### PR DESCRIPTION
when we define primaryEndpoint in format $IP:$PORT a deploed replica in standby cluster fails. 
without this replication slots cannot be created because of the way how we create connection to primary DB that can be used by the operator.
this fix used predefined port as currently we don't allow to define port for primary endpoint

Related: https://github.com/tetrateio/tetrate/issues/26650