### PR TITLE
cves: bump pgx/v5 to v5.9.1, release `v1.16.0-tetrate-v34`

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v33
+  newTag: v1.16.0-tetrate-v34

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3
-	github.com/jackc/pgx/v5 v5.7.5
+	github.com/jackc/pgx/v5 v5.9.1
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.5 h1:JHGfMnQY+IEtGM63d+NGMjoRpysB2JBwDr5fsngwmJs=
-github.com/jackc/pgx/v5 v5.7.5/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
+github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -1,5 +1,3 @@
-# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
-# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -68,8 +66,7 @@ spec:
                 type: object
               env:
                 items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
+                  description: EnvVar represents an environment variable present in a Container.
                   properties:
                     name:
                       description: Name of the environment variable. Must be a C_IDENTIFIER.
@@ -87,8 +84,7 @@ spec:
                         Defaults to "".
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
+                      description: Source for the environment variable's value. Cannot be used if value is not empty.
                       properties:
                         configMapKeyRef:
                           description: Selects a key of a ConfigMap.
@@ -102,8 +98,7 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
+                              description: Specify whether the ConfigMap or its key must be defined
                               type: boolean
                           required:
                           - key
@@ -115,12 +110,10 @@ spec:
                             spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
+                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
+                              description: Path of the field to select in the specified API version.
                               type: string
                           required:
                           - fieldPath
@@ -132,15 +125,13 @@ spec:
                             (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
+                              description: 'Container name: required for volumes, optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
+                              description: Specifies the output format of the exposed resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
@@ -154,8 +145,7 @@ spec:
                           description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                              description: The key of the secret to select from.  Must be a valid secret key.
                               type: string
                             name:
                               description: |-
@@ -163,8 +153,7 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
+                              description: Specify whether the Secret or its key must be defined
                               type: boolean
                           required:
                           - key
@@ -234,8 +223,7 @@ spec:
                           This is a beta field and requires enabling GRPCContainerProbe feature gate.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
+                            description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
@@ -258,11 +246,9 @@ spec:
                               "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
+                            description: Custom headers to set in the request. HTTP allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
+                              description: HTTPHeader describes a custom header to be used in HTTP probes
                               properties:
                                 name:
                                   description: The header field name
@@ -314,12 +300,10 @@ spec:
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
+                        description: TCPSocket specifies an action involving a TCP port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
+                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                             type: string
                           port:
                             anyOf:
@@ -386,8 +370,7 @@ spec:
                           This is a beta field and requires enabling GRPCContainerProbe feature gate.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
+                            description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
@@ -410,11 +393,9 @@ spec:
                               "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
+                            description: Custom headers to set in the request. HTTP allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
+                              description: HTTPHeader describes a custom header to be used in HTTP probes
                               properties:
                                 name:
                                   description: The header field name
@@ -466,12 +447,10 @@ spec:
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
+                        description: TCPSocket specifies an action involving a TCP port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
+                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                             type: string
                           port:
                             anyOf:
@@ -520,8 +499,7 @@ spec:
                       By default, this is set to false, allowing the system to clean up inactive slots based on the defined grace period.
                     type: boolean
                   enabled:
-                    description: Enabled indicates whether the replication slots feature
-                      is activated.
+                    description: Enabled indicates whether the replication slots feature is activated.
                     type: boolean
                   healthCheckInterval:
                     default: 30s
@@ -584,8 +562,7 @@ spec:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
+                        description: Describes node affinity scheduling rules for the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -604,20 +581,17 @@ spec:
                                 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
+                                  description: A node selector term, associated with the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
+                                      description: A list of node selector requirements by node's labels.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
+                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -640,16 +614,14 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
+                                      description: A list of node selector requirements by node's fields.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
+                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -674,8 +646,7 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -692,8 +663,7 @@ spec:
                               may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
+                                description: Required. A list of node selector terms. The terms are ORed.
                                 items:
                                   description: |-
                                     A null or empty node selector term matches no objects. The requirements of
@@ -701,16 +671,14 @@ spec:
                                     The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
+                                      description: A list of node selector requirements by node's labels.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
+                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -733,16 +701,14 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
+                                      description: A list of node selector requirements by node's fields.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector
-                                              applies to.
+                                            description: The label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -773,9 +739,7 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -789,30 +753,23 @@ spec:
                               "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
+                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -852,17 +809,14 @@ spec:
                                         An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -943,21 +897,17 @@ spec:
                                 a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -997,17 +947,14 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1061,9 +1008,7 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -1077,30 +1022,23 @@ spec:
                               "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
+                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -1140,17 +1078,14 @@ spec:
                                         An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -1231,21 +1166,17 @@ spec:
                                 a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
+                                  description: A label query over a set of resources, in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1285,17 +1216,14 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1457,20 +1385,16 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to
-                          the container.
+                        description: Level is SELinux level label that applies to the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to
-                          the container.
+                        description: Role is a SELinux role label that applies to the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to
-                          the container.
+                        description: Type is a SELinux type label that applies to the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to
-                          the container.
+                        description: User is a SELinux user label that applies to the container.
                         type: string
                     type: object
                   seccompProfile:
@@ -1540,8 +1464,7 @@ spec:
                           GMSA credential spec named by the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA
-                          credential spec to use.
+                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                         type: string
                       hostProcess:
                         description: |-
@@ -1566,8 +1489,7 @@ spec:
                 type: string
               sidecarContainers:
                 items:
-                  description: A single application container that you want to run
-                    within a pod.
+                  description: A single application container that you want to run within a pod.
                   properties:
                     args:
                       description: |-
@@ -1600,12 +1522,10 @@ spec:
                         List of environment variables to set in the container.
                         Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
+                        description: EnvVar represents an environment variable present in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
+                            description: Name of the environment variable. Must be a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -1620,8 +1540,7 @@ spec:
                               Defaults to "".
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
                                 description: Selects a key of a ConfigMap.
@@ -1635,8 +1554,7 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its key must be defined
+                                    description: Specify whether the ConfigMap or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1648,12 +1566,10 @@ spec:
                                   spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
+                                    description: Path of the field to select in the specified API version.
                                     type: string
                                 required:
                                 - fieldPath
@@ -1665,15 +1581,13 @@ spec:
                                   (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
+                                    description: 'Container name: required for volumes, optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
@@ -1684,12 +1598,10 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
+                                description: Selects a key of a secret in the pod's namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
+                                    description: The key of the secret to select from.  Must be a valid secret key.
                                     type: string
                                   name:
                                     description: |-
@@ -1697,8 +1609,7 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
+                                    description: Specify whether the Secret or its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1718,8 +1629,7 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set
-                          of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -1730,14 +1640,12 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be
-                                  defined
+                                description: Specify whether the ConfigMap must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -1804,11 +1712,9 @@ spec:
                                     "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -1848,8 +1754,7 @@ spec:
                                 lifecycle hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
@@ -1899,11 +1804,9 @@ spec:
                                     "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -1943,8 +1846,7 @@ spec:
                                 lifecycle hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
@@ -1993,8 +1895,7 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -2017,11 +1918,9 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
+                              description: Custom headers to set in the request. HTTP allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
+                                description: HTTPHeader describes a custom header to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -2073,12 +1972,10 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
+                          description: TCPSocket specifies an action involving a TCP port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2130,8 +2027,7 @@ spec:
                         For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                         Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a
-                          single container.
+                        description: ContainerPort represents a network port in a single container.
                         properties:
                           containerPort:
                             description: |-
@@ -2203,8 +2099,7 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -2227,11 +2122,9 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
+                              description: Custom headers to set in the request. HTTP allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
+                                description: HTTPHeader describes a custom header to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -2283,12 +2176,10 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
+                          description: TCPSocket specifies an action involving a TCP port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2380,15 +2271,13 @@ spec:
                             add:
                               description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
+                                description: Capability represent POSIX capabilities type
                                 type: string
                               type: array
                             drop:
                               description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
+                                description: Capability represent POSIX capabilities type
                                 type: string
                               type: array
                           type: object
@@ -2449,20 +2338,16 @@ spec:
                             Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
+                              description: Level is SELinux level label that applies to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
+                              description: Role is a SELinux role label that applies to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
+                              description: Type is a SELinux type label that applies to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
+                              description: User is a SELinux user label that applies to the container.
                               type: string
                           type: object
                         seccompProfile:
@@ -2505,8 +2390,7 @@ spec:
                                 GMSA credential spec named by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
+                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                               type: string
                             hostProcess:
                               description: |-
@@ -2563,8 +2447,7 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -2587,11 +2470,9 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
+                              description: Custom headers to set in the request. HTTP allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
+                                description: HTTPHeader describes a custom header to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -2643,12 +2524,10 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
+                          description: TCPSocket specifies an action involving a TCP port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2726,19 +2605,15 @@ spec:
                         Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be
-                        used by the container.
+                      description: volumeDevices is the list of block devices to be used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block
-                          device within a container.
+                        description: volumeDevice describes a mapping of a raw block device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container
-                              that the device will be mapped to.
+                            description: devicePath is the path inside of the container that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim
-                              in the pod
+                            description: name must match the name of a persistentVolumeClaim in the pod
                             type: string
                         required:
                         - devicePath
@@ -2750,8 +2625,7 @@ spec:
                         Pod volumes to mount into the container's filesystem.
                         Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
+                        description: VolumeMount describes a mounting of a Volume within a container.
                         properties:
                           mountPath:
                             description: |-
@@ -2811,8 +2685,7 @@ spec:
               tls:
                 properties:
                   clientCert:
-                    description: ClientCertPath is the path to the client certificate
-                      file.
+                    description: ClientCertPath is the path to the client certificate file.
                     type: string
                   clientKey:
                     description: ClientKeyPath is the path to the client key file.
@@ -2821,16 +2694,13 @@ spec:
                     description: SSLMode honors https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION.
                     type: string
                   rootCert:
-                    description: RootCertPath is the path to the root certificate
-                      file.
+                    description: RootCertPath is the path to the root certificate file.
                     type: string
                   secretName:
-                    description: SecretName is the name of the Kubernetes secret that
-                      contains the TLS certificates.
+                    description: SecretName is the name of the Kubernetes secret that contains the TLS certificates.
                     type: string
                   serverCert:
-                    description: ServerCertPath is the path to the server certificate
-                      file.
+                    description: ServerCertPath is the path to the server certificate file.
                     type: string
                   serverKey:
                     description: ServerKeyPath is the path to the server key file.
@@ -2877,12 +2747,10 @@ spec:
                                         For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
+                                      description: Kind is the type of resource being referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
+                                      description: Name is the name of resource being referenced
                                       type: string
                                   required:
                                   - kind
@@ -2916,12 +2784,10 @@ spec:
                                         For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
+                                      description: Kind is the type of resource being referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
+                                      description: Name is the name of resource being referenced
                                       type: string
                                   required:
                                   - kind
@@ -2962,21 +2828,17 @@ spec:
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
+                                  description: selector is a label query over volumes to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
+                                            description: key is the label key that the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -3018,16 +2880,14 @@ spec:
                                     Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
+                                  description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           type: object
                         type: array
                       volumeMounts:
                         items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
+                          description: VolumeMount describes a mounting of a Volume within a container.
                           properties:
                             mountPath:
                               description: |-
@@ -3068,8 +2928,7 @@ spec:
                         type: array
                       volumes:
                         items:
-                          description: Volume represents a named volume in a pod that
-                            may be accessed by any container in the pod.
+                          description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
                               description: |-
@@ -3106,20 +2965,16 @@ spec:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
                                   description: |-
@@ -3128,11 +2983,7 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -3144,8 +2995,7 @@ spec:
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
                                   description: |-
@@ -3153,8 +3003,7 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
                                   description: shareName is the azure share Name
@@ -3164,8 +3013,7 @@ spec:
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
                                   description: |-
@@ -3175,9 +3023,7 @@ spec:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -3249,8 +3095,7 @@ spec:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
                                   description: |-
@@ -3273,8 +3118,7 @@ spec:
                                     the volume setup will error unless it is marked optional. Paths must be
                                     relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: key is the key to project.
@@ -3307,15 +3151,12 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
                                   description: |-
@@ -3359,8 +3200,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: |-
@@ -3375,26 +3215,18 @@ spec:
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
+                                  description: Items is a list of downward API volume file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
+                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
+                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
+                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
@@ -3411,11 +3243,7 @@ spec:
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
+                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
                                         description: |-
@@ -3423,16 +3251,13 @@ spec:
                                           (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
+                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
@@ -3561,12 +3386,10 @@ spec:
                                                 For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
+                                              description: Kind is the type of resource being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
+                                              description: Name is the name of resource being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3600,12 +3423,10 @@ spec:
                                                 For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
+                                              description: Kind is the type of resource being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
+                                              description: Name is the name of resource being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3646,22 +3467,17 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
                                                 description: |-
                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                   relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
+                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
                                                     description: |-
@@ -3703,8 +3519,7 @@ spec:
                                             Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3712,9 +3527,7 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
                                   description: |-
@@ -3732,8 +3545,7 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
@@ -3751,8 +3563,7 @@ spec:
                                 provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
                                   description: |-
@@ -3763,8 +3574,7 @@ spec:
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
                                   description: |-
@@ -3790,9 +3600,7 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
                                   description: |-
@@ -3800,8 +3608,7 @@ spec:
                                     should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
@@ -3858,8 +3665,7 @@ spec:
                                   description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
@@ -3919,12 +3725,10 @@ spec:
                                 More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
                                   description: |-
@@ -3964,8 +3768,7 @@ spec:
                                     Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: |-
@@ -4035,9 +3838,7 @@ spec:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
                                   description: |-
@@ -4046,15 +3847,13 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
                                   description: |-
@@ -4068,15 +3867,13 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
                                   description: |-
@@ -4091,12 +3888,10 @@ spec:
                                 sources:
                                   description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
+                                    description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
                                             description: |-
@@ -4108,8 +3903,7 @@ spec:
                                               the volume setup will error unless it is marked optional. Paths must be
                                               relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
+                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
                                                   description: key is the key to project.
@@ -4142,38 +3936,26 @@ spec:
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
+                                            description: Items is a list of DownwardAPIVolume file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
+                                              description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
+                                                  description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
+                                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
+                                                      description: Path of the field to select in the specified API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
@@ -4190,13 +3972,7 @@ spec:
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
+                                                  description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
                                                   description: |-
@@ -4204,22 +3980,17 @@ spec:
                                                     (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
+                                                      description: 'Container name: required for volumes, optional for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
+                                                      description: Specifies the output format of the exposed resources, defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
+                                                      description: 'Required: resource to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -4231,8 +4002,7 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
                                             description: |-
@@ -4244,8 +4014,7 @@ spec:
                                               the volume setup will error unless it is marked optional. Paths must be
                                               relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
+                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
                                                   description: key is the key to project.
@@ -4278,14 +4047,12 @@ spec:
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
                                             description: |-
@@ -4316,8 +4083,7 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
                                   description: |-
@@ -4346,8 +4112,7 @@ spec:
                                     Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
@@ -4420,8 +4185,7 @@ spec:
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
                                   description: |-
@@ -4431,12 +4195,10 @@ spec:
                                     Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
                                   description: |-
@@ -4456,8 +4218,7 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
                                   description: |-
@@ -4465,12 +4226,10 @@ spec:
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
                                   description: |-
@@ -4508,8 +4267,7 @@ spec:
                                     the volume setup will error unless it is marked optional. Paths must be
                                     relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
+                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
                                         description: key is the key to project.
@@ -4537,8 +4295,7 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
                                   description: |-
@@ -4547,8 +4304,7 @@ spec:
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
                                   description: |-
@@ -4589,8 +4345,7 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
                                   description: |-
@@ -4599,17 +4354,13 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4653,12 +4404,10 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
+                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
+                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                               - kind
@@ -4692,12 +4441,10 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being
-                                    referenced
+                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being
-                                    referenced
+                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                               - kind
@@ -4738,20 +4485,17 @@ spec:
                                   type: object
                               type: object
                             selector:
-                              description: selector is a label query over volumes
-                                to consider for binding.
+                              description: selector is a label query over volumes to consider for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
+                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -4793,16 +4537,14 @@ spec:
                                 Value of Filesystem is implied when not included in claim spec.
                               type: string
                             volumeName:
-                              description: volumeName is the binding reference to
-                                the PersistentVolume backing this claim.
+                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
                               type: string
                           type: object
                       type: object
                     type: array
                   volumeMounts:
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
+                      description: VolumeMount describes a mounting of a Volume within a container.
                       properties:
                         mountPath:
                           description: |-
@@ -4843,8 +4585,7 @@ spec:
                     type: array
                   volumes:
                     items:
-                      description: Volume represents a named volume in a pod that
-                        may be accessed by any container in the pod.
+                      description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
                           description: |-
@@ -4881,20 +4622,16 @@ spec:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: azureDisk represents an Azure Data Disk mount
-                            on the host and bind mount to the pod.
+                          description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'cachingMode is the Host Caching mode:
-                                None, Read Only, Read Write.'
+                              description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                               type: string
                             diskName:
-                              description: diskName is the Name of the data disk in
-                                the blob storage
+                              description: diskName is the Name of the data disk in the blob storage
                               type: string
                             diskURI:
-                              description: diskURI is the URI of data disk in the
-                                blob storage
+                              description: diskURI is the URI of data disk in the blob storage
                               type: string
                             fsType:
                               description: |-
@@ -4903,11 +4640,7 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             kind:
-                              description: 'kind expected values are Shared: multiple
-                                blob disks per storage account  Dedicated: single
-                                blob disk per storage account  Managed: azure managed
-                                data disk (only in managed availability set). defaults
-                                to shared'
+                              description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                               type: string
                             readOnly:
                               description: |-
@@ -4919,8 +4652,7 @@ spec:
                           - diskURI
                           type: object
                         azureFile:
-                          description: azureFile represents an Azure File Service
-                            mount on the host and bind mount to the pod.
+                          description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
                               description: |-
@@ -4928,8 +4660,7 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: secretName is the  name of secret that
-                                contains Azure Storage Account Name and Key
+                              description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                               type: string
                             shareName:
                               description: shareName is the azure share Name
@@ -4939,8 +4670,7 @@ spec:
                           - shareName
                           type: object
                         cephfs:
-                          description: cephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
+                          description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                           properties:
                             monitors:
                               description: |-
@@ -4950,8 +4680,7 @@ spec:
                                 type: string
                               type: array
                             path:
-                              description: 'path is Optional: Used as the mounted
-                                root, rather than the full Ceph tree, default is /'
+                              description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
                               description: |-
@@ -5023,8 +4752,7 @@ spec:
                           - volumeID
                           type: object
                         configMap:
-                          description: configMap represents a configMap that should
-                            populate this volume
+                          description: configMap represents a configMap that should populate this volume
                           properties:
                             defaultMode:
                               description: |-
@@ -5047,8 +4775,7 @@ spec:
                                 the volume setup will error unless it is marked optional. Paths must be
                                 relative and may not contain the '..' path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
+                                description: Maps a string key to a path within a volume.
                                 properties:
                                   key:
                                     description: key is the key to project.
@@ -5081,15 +4808,12 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: optional specify whether the ConfigMap
-                                or its keys must be defined
+                              description: optional specify whether the ConfigMap or its keys must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         csi:
-                          description: csi (Container Storage Interface) represents
-                            ephemeral storage that is handled by certain external
-                            CSI drivers (Beta feature).
+                          description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                           properties:
                             driver:
                               description: |-
@@ -5133,8 +4857,7 @@ spec:
                           - driver
                           type: object
                         downwardAPI:
-                          description: downwardAPI represents downward API about the
-                            pod that should populate this volume
+                          description: downwardAPI represents downward API about the pod that should populate this volume
                           properties:
                             defaultMode:
                               description: |-
@@ -5149,24 +4872,18 @@ spec:
                               format: int32
                               type: integer
                             items:
-                              description: Items is a list of downward API volume
-                                file
+                              description: Items is a list of downward API volume file
                               items:
-                                description: DownwardAPIVolumeFile represents information
-                                  to create the file containing the pod field
+                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                 properties:
                                   fieldRef:
-                                    description: 'Required: Selects a field of the
-                                      pod: only annotations, labels, name and namespace
-                                      are supported.'
+                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
+                                        description: Path of the field to select in the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
@@ -5183,11 +4900,7 @@ spec:
                                     format: int32
                                     type: integer
                                   path:
-                                    description: 'Required: Path is  the relative
-                                      path name of the file to be created. Must not
-                                      be absolute or contain the ''..'' path. Must
-                                      be utf-8 encoded. The first item of the relative
-                                      path must not start with ''..'''
+                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                     type: string
                                   resourceFieldRef:
                                     description: |-
@@ -5195,15 +4908,13 @@ spec:
                                       (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
+                                        description: 'Container name: required for volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
@@ -5332,12 +5043,10 @@ spec:
                                             For any other third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
+                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
+                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                       - kind
@@ -5371,12 +5080,10 @@ spec:
                                             For any other third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource
-                                            being referenced
+                                          description: Kind is the type of resource being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource
-                                            being referenced
+                                          description: Name is the name of resource being referenced
                                           type: string
                                       required:
                                       - kind
@@ -5417,21 +5124,17 @@ spec:
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over
-                                        volumes to consider for binding.
+                                      description: selector is a label query over volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key
-                                                  that the selector applies to.
+                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -5473,8 +5176,7 @@ spec:
                                         Value of Filesystem is implied when not included in claim spec.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference
-                                        to the PersistentVolume backing this claim.
+                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -5482,9 +5184,7 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: fc represents a Fibre Channel resource that
-                            is attached to a kubelet's host machine and then exposed
-                            to the pod.
+                          description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                           properties:
                             fsType:
                               description: |-
@@ -5502,8 +5202,7 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             targetWWNs:
-                              description: 'targetWWNs is Optional: FC target worldwide
-                                names (WWNs)'
+                              description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                               items:
                                 type: string
                               type: array
@@ -5521,8 +5220,7 @@ spec:
                             provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: driver is the name of the driver to use
-                                for this volume.
+                              description: driver is the name of the driver to use for this volume.
                               type: string
                             fsType:
                               description: |-
@@ -5533,8 +5231,7 @@ spec:
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'options is Optional: this field holds
-                                extra command options if any.'
+                              description: 'options is Optional: this field holds extra command options if any.'
                               type: object
                             readOnly:
                               description: |-
@@ -5560,9 +5257,7 @@ spec:
                           - driver
                           type: object
                         flocker:
-                          description: flocker represents a Flocker volume attached
-                            to a kubelet's host machine. This depends on the Flocker
-                            control service being running
+                          description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                           properties:
                             datasetName:
                               description: |-
@@ -5570,8 +5265,7 @@ spec:
                                 should be considered as deprecated
                               type: string
                             datasetUUID:
-                              description: datasetUUID is the UUID of the dataset.
-                                This is unique identifier of a Flocker dataset
+                              description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
@@ -5628,8 +5322,7 @@ spec:
                               description: repository is the URL
                               type: string
                             revision:
-                              description: revision is the commit hash for the specified
-                                revision.
+                              description: revision is the commit hash for the specified revision.
                               type: string
                           required:
                           - repository
@@ -5689,12 +5382,10 @@ spec:
                             More info: https://examples.k8s.io/volumes/iscsi/README.md
                           properties:
                             chapAuthDiscovery:
-                              description: chapAuthDiscovery defines whether support
-                                iSCSI Discovery CHAP authentication
+                              description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: chapAuthSession defines whether support
-                                iSCSI Session CHAP authentication
+                              description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
                               description: |-
@@ -5734,8 +5425,7 @@ spec:
                                 Defaults to false.
                               type: boolean
                             secretRef:
-                              description: secretRef is the CHAP Secret for iSCSI
-                                target and initiator authentication
+                              description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                               properties:
                                 name:
                                   description: |-
@@ -5805,9 +5495,7 @@ spec:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: photonPersistentDisk represents a PhotonController
-                            persistent disk attached and mounted on kubelets host
-                            machine
+                          description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                           properties:
                             fsType:
                               description: |-
@@ -5816,15 +5504,13 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             pdID:
-                              description: pdID is the ID that identifies Photon Controller
-                                persistent disk
+                              description: pdID is the ID that identifies Photon Controller persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: portworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
+                          description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                           properties:
                             fsType:
                               description: |-
@@ -5838,15 +5524,13 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: volumeID uniquely identifies a Portworx
-                                volume
+                              description: volumeID uniquely identifies a Portworx volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: projected items for all in one resources secrets,
-                            configmaps, and downward API
+                          description: projected items for all in one resources secrets, configmaps, and downward API
                           properties:
                             defaultMode:
                               description: |-
@@ -5861,12 +5545,10 @@ spec:
                             sources:
                               description: sources is the list of volume projections
                               items:
-                                description: Projection that may be projected along
-                                  with other supported volume types
+                                description: Projection that may be projected along with other supported volume types
                                 properties:
                                   configMap:
-                                    description: configMap information about the configMap
-                                      data to project
+                                    description: configMap information about the configMap data to project
                                     properties:
                                       items:
                                         description: |-
@@ -5878,8 +5560,7 @@ spec:
                                           the volume setup will error unless it is marked optional. Paths must be
                                           relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
+                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
                                               description: key is the key to project.
@@ -5912,36 +5593,26 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
-                                        description: optional specify whether the
-                                          ConfigMap or its keys must be defined
+                                        description: optional specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   downwardAPI:
-                                    description: downwardAPI information about the
-                                      downwardAPI data to project
+                                    description: downwardAPI information about the downwardAPI data to project
                                     properties:
                                       items:
-                                        description: Items is a list of DownwardAPIVolume
-                                          file
+                                        description: Items is a list of DownwardAPIVolume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents
-                                            information to create the file containing
-                                            the pod field
+                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field
-                                                of the pod: only annotations, labels,
-                                                name and namespace are supported.'
+                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema
-                                                    the FieldPath is written in terms
-                                                    of, defaults to "v1".
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to
-                                                    select in the specified API version.
+                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
@@ -5958,12 +5629,7 @@ spec:
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the
-                                                relative path name of the file to
-                                                be created. Must not be absolute or
-                                                contain the ''..'' path. Must be utf-8
-                                                encoded. The first item of the relative
-                                                path must not start with ''..'''
+                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
                                               description: |-
@@ -5971,22 +5637,17 @@ spec:
                                                 (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required
-                                                    for volumes, optional for env
-                                                    vars'
+                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output
-                                                    format of the exposed resources,
-                                                    defaults to "1"
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource
-                                                    to select'
+                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -5998,8 +5659,7 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: secret information about the secret
-                                      data to project
+                                    description: secret information about the secret data to project
                                     properties:
                                       items:
                                         description: |-
@@ -6011,8 +5671,7 @@ spec:
                                           the volume setup will error unless it is marked optional. Paths must be
                                           relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path
-                                            within a volume.
+                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
                                               description: key is the key to project.
@@ -6045,14 +5704,12 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
-                                        description: optional field specify whether
-                                          the Secret or its key must be defined
+                                        description: optional field specify whether the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   serviceAccountToken:
-                                    description: serviceAccountToken is information
-                                      about the serviceAccountToken data to project
+                                    description: serviceAccountToken is information about the serviceAccountToken data to project
                                     properties:
                                       audience:
                                         description: |-
@@ -6083,8 +5740,7 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
+                          description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                           properties:
                             group:
                               description: |-
@@ -6113,8 +5769,7 @@ spec:
                                 Defaults to serivceaccount user
                               type: string
                             volume:
-                              description: volume is a string that references an already
-                                created Quobyte volume by name.
+                              description: volume is a string that references an already created Quobyte volume by name.
                               type: string
                           required:
                           - registry
@@ -6187,8 +5842,7 @@ spec:
                           - monitors
                           type: object
                         scaleIO:
-                          description: scaleIO represents a ScaleIO persistent volume
-                            attached and mounted on Kubernetes nodes.
+                          description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
                               description: |-
@@ -6198,12 +5852,10 @@ spec:
                                 Default is "xfs".
                               type: string
                             gateway:
-                              description: gateway is the host address of the ScaleIO
-                                API Gateway.
+                              description: gateway is the host address of the ScaleIO API Gateway.
                               type: string
                             protectionDomain:
-                              description: protectionDomain is the name of the ScaleIO
-                                Protection Domain for the configured storage.
+                              description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                               type: string
                             readOnly:
                               description: |-
@@ -6223,8 +5875,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             sslEnabled:
-                              description: sslEnabled Flag enable/disable SSL communication
-                                with Gateway, default false
+                              description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                               type: boolean
                             storageMode:
                               description: |-
@@ -6232,12 +5883,10 @@ spec:
                                 Default is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: storagePool is the ScaleIO Storage Pool
-                                associated with the protection domain.
+                              description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                               type: string
                             system:
-                              description: system is the name of the storage system
-                                as configured in ScaleIO.
+                              description: system is the name of the storage system as configured in ScaleIO.
                               type: string
                             volumeName:
                               description: |-
@@ -6275,8 +5924,7 @@ spec:
                                 the volume setup will error unless it is marked optional. Paths must be
                                 relative and may not contain the '..' path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a
-                                  volume.
+                                description: Maps a string key to a path within a volume.
                                 properties:
                                   key:
                                     description: key is the key to project.
@@ -6304,8 +5952,7 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: optional field specify whether the Secret
-                                or its keys must be defined
+                              description: optional field specify whether the Secret or its keys must be defined
                               type: boolean
                             secretName:
                               description: |-
@@ -6314,8 +5961,7 @@ spec:
                               type: string
                           type: object
                         storageos:
-                          description: storageOS represents a StorageOS volume attached
-                            and mounted on Kubernetes nodes.
+                          description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
                               description: |-
@@ -6356,8 +6002,7 @@ spec:
                               type: string
                           type: object
                         vsphereVolume:
-                          description: vsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
+                          description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                           properties:
                             fsType:
                               description: |-
@@ -6366,16 +6011,13 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             storagePolicyID:
-                              description: storagePolicyID is the storage Policy Based
-                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: storagePolicyName is the storage Policy
-                                Based Management (SPBM) profile name.
+                              description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                               type: string
                             volumePath:
-                              description: volumePath is the path that identifies
-                                vSphere volume vmdk
+                              description: volumePath is the path that identifies vSphere volume vmdk
                               type: string
                           required:
                           - volumePath

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -1,3 +1,5 @@
+# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
+# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -66,7 +68,8 @@ spec:
                 type: object
               env:
                 items:
-                  description: EnvVar represents an environment variable present in a Container.
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
                       description: Name of the environment variable. Must be a C_IDENTIFIER.
@@ -84,7 +87,8 @@ spec:
                         Defaults to "".
                       type: string
                     valueFrom:
-                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
                           description: Selects a key of a ConfigMap.
@@ -98,7 +102,8 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its key must be defined
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
@@ -110,10 +115,12 @@ spec:
                             spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                           properties:
                             apiVersion:
-                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
-                              description: Path of the field to select in the specified API version.
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
@@ -125,13 +132,15 @@ spec:
                             (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                           properties:
                             containerName:
-                              description: 'Container name: required for volumes, optional for env vars'
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
@@ -145,7 +154,8 @@ spec:
                           description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must be a valid secret key.
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               description: |-
@@ -153,7 +163,8 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must be defined
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -223,7 +234,8 @@ spec:
                           This is a beta field and requires enabling GRPCContainerProbe feature gate.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
@@ -246,9 +258,11 @@ spec:
                               "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
                                   description: The header field name
@@ -300,10 +314,12 @@ spec:
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP port.
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
@@ -370,7 +386,8 @@ spec:
                           This is a beta field and requires enabling GRPCContainerProbe feature gate.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
@@ -393,9 +410,11 @@ spec:
                               "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
                                   description: The header field name
@@ -447,10 +466,12 @@ spec:
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP port.
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
@@ -499,7 +520,8 @@ spec:
                       By default, this is set to false, allowing the system to clean up inactive slots based on the defined grace period.
                     type: boolean
                   enabled:
-                    description: Enabled indicates whether the replication slots feature is activated.
+                    description: Enabled indicates whether the replication slots feature
+                      is activated.
                     type: boolean
                   healthCheckInterval:
                     default: 30s
@@ -562,7 +584,8 @@ spec:
                     description: Affinity is a group of affinity scheduling rules.
                     properties:
                       nodeAffinity:
-                        description: Describes node affinity scheduling rules for the pod.
+                        description: Describes node affinity scheduling rules for
+                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -581,17 +604,20 @@ spec:
                                 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                               properties:
                                 preference:
-                                  description: A node selector term, associated with the corresponding weight.
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -614,14 +640,16 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -646,7 +674,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
-                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -663,7 +692,8 @@ spec:
                               may or may not try to eventually evict the pod from its node.
                             properties:
                               nodeSelectorTerms:
-                                description: Required. A list of node selector terms. The terms are ORed.
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
                                 items:
                                   description: |-
                                     A null or empty node selector term matches no objects. The requirements of
@@ -671,14 +701,16 @@ spec:
                                     The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                   properties:
                                     matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -701,14 +733,16 @@ spec:
                                         type: object
                                       type: array
                                     matchFields:
-                                      description: A list of node selector requirements by node's fields.
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
                                         description: |-
                                           A node selector requirement is a selector that contains values, a key, and an operator
                                           that relates the key and values.
                                         properties:
                                           key:
-                                            description: The label key that the selector applies to.
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -739,7 +773,9 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -753,23 +789,30 @@ spec:
                               "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
+                                      description: A label query over a set of resources,
+                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -809,14 +852,17 @@ spec:
                                         An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -897,17 +943,21 @@ spec:
                                 a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -947,14 +997,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1008,7 +1061,9 @@ spec:
                             type: array
                         type: object
                       podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
@@ -1022,23 +1077,30 @@ spec:
                               "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
+                                      description: A label query over a set of resources,
+                                        in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -1078,14 +1140,17 @@ spec:
                                         An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -1166,17 +1231,21 @@ spec:
                                 a pod of the set of pods is running
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1216,14 +1285,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -1385,16 +1457,20 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to the container.
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to the container.
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to the container.
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to the container.
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
@@ -1464,7 +1540,8 @@ spec:
                           GMSA credential spec named by the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
                         description: |-
@@ -1489,7 +1566,8 @@ spec:
                 type: string
               sidecarContainers:
                 items:
-                  description: A single application container that you want to run within a pod.
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
                       description: |-
@@ -1522,10 +1600,12 @@ spec:
                         List of environment variables to set in the container.
                         Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present in a Container.
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -1540,7 +1620,8 @@ spec:
                               Defaults to "".
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
                                 description: Selects a key of a ConfigMap.
@@ -1554,7 +1635,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1566,10 +1648,12 @@ spec:
                                   spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the specified API version.
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
@@ -1581,13 +1665,15 @@ spec:
                                   (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
@@ -1598,10 +1684,12 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     description: |-
@@ -1609,7 +1697,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1629,7 +1718,8 @@ spec:
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -1640,12 +1730,14 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be defined
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -1712,9 +1804,11 @@ spec:
                                     "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -1754,7 +1848,8 @@ spec:
                                 lifecycle hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
@@ -1804,9 +1899,11 @@ spec:
                                     "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
                                         description: The header field name
@@ -1846,7 +1943,8 @@ spec:
                                 lifecycle hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
@@ -1895,7 +1993,8 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -1918,9 +2017,11 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -1972,10 +2073,12 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2027,7 +2130,8 @@ spec:
                         For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                         Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a single container.
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
                             description: |-
@@ -2099,7 +2203,8 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -2122,9 +2227,11 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -2176,10 +2283,12 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2271,13 +2380,15 @@ spec:
                             add:
                               description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                             drop:
                               description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities type
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                           type: object
@@ -2338,16 +2449,20 @@ spec:
                             Note that this field cannot be set when spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies to the container.
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies to the container.
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies to the container.
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies to the container.
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
@@ -2390,7 +2505,8 @@ spec:
                                 GMSA credential spec named by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
                               description: |-
@@ -2447,7 +2563,8 @@ spec:
                             This is a beta field and requires enabling GRPCContainerProbe feature gate.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
@@ -2470,9 +2587,11 @@ spec:
                                 "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
                                     description: The header field name
@@ -2524,10 +2643,12 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
@@ -2605,15 +2726,19 @@ spec:
                         Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be used by the container.
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block device within a container.
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container that the device will be mapped to.
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim in the pod
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -2625,7 +2750,8 @@ spec:
                         Pod volumes to mount into the container's filesystem.
                         Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume within a container.
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
                             description: |-
@@ -2685,7 +2811,8 @@ spec:
               tls:
                 properties:
                   clientCert:
-                    description: ClientCertPath is the path to the client certificate file.
+                    description: ClientCertPath is the path to the client certificate
+                      file.
                     type: string
                   clientKey:
                     description: ClientKeyPath is the path to the client key file.
@@ -2694,13 +2821,16 @@ spec:
                     description: SSLMode honors https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION.
                     type: string
                   rootCert:
-                    description: RootCertPath is the path to the root certificate file.
+                    description: RootCertPath is the path to the root certificate
+                      file.
                     type: string
                   secretName:
-                    description: SecretName is the name of the Kubernetes secret that contains the TLS certificates.
+                    description: SecretName is the name of the Kubernetes secret that
+                      contains the TLS certificates.
                     type: string
                   serverCert:
-                    description: ServerCertPath is the path to the server certificate file.
+                    description: ServerCertPath is the path to the server certificate
+                      file.
                     type: string
                   serverKey:
                     description: ServerKeyPath is the path to the server key file.
@@ -2747,10 +2877,12 @@ spec:
                                         For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being referenced
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being referenced
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2784,10 +2916,12 @@ spec:
                                         For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being referenced
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being referenced
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2828,17 +2962,21 @@ spec:
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes to consider for binding.
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -2880,14 +3018,16 @@ spec:
                                     Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           type: object
                         type: array
                       volumeMounts:
                         items:
-                          description: VolumeMount describes a mounting of a Volume within a container.
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
                           properties:
                             mountPath:
                               description: |-
@@ -2928,7 +3068,8 @@ spec:
                         type: array
                       volumes:
                         items:
-                          description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
                               description: |-
@@ -2965,16 +3106,20 @@ spec:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
                                   description: |-
@@ -2983,7 +3128,11 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -2995,7 +3144,8 @@ spec:
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
                                   description: |-
@@ -3003,7 +3153,8 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
                                   description: shareName is the azure share Name
@@ -3013,7 +3164,8 @@ spec:
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 monitors:
                                   description: |-
@@ -3023,7 +3175,9 @@ spec:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
                                   description: |-
@@ -3095,7 +3249,8 @@ spec:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should
+                                populate this volume
                               properties:
                                 defaultMode:
                                   description: |-
@@ -3118,7 +3273,8 @@ spec:
                                     the volume setup will error unless it is marked optional. Paths must be
                                     relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within a volume.
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
                                         description: key is the key to project.
@@ -3151,12 +3307,15 @@ spec:
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
                               properties:
                                 driver:
                                   description: |-
@@ -3200,7 +3359,8 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: |-
@@ -3215,18 +3375,26 @@ spec:
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume file
+                                  description: Items is a list of downward API volume
+                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select in the specified API version.
+                                            description: Path of the field to select
+                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
@@ -3243,7 +3411,11 @@ spec:
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
                                         description: |-
@@ -3251,13 +3423,16 @@ spec:
                                           (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
@@ -3386,10 +3561,12 @@ spec:
                                                 For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource being referenced
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource being referenced
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3423,10 +3600,12 @@ spec:
                                                 For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource being referenced
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource being referenced
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3467,17 +3646,22 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over volumes to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
                                                 description: |-
                                                   A label selector requirement is a selector that contains values, a key, and an operator that
                                                   relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
                                                     description: |-
@@ -3519,7 +3703,8 @@ spec:
                                             Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3527,7 +3712,9 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
                               properties:
                                 fsType:
                                   description: |-
@@ -3545,7 +3732,8 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
@@ -3563,7 +3751,8 @@ spec:
                                 provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to
+                                    use for this volume.
                                   type: string
                                 fsType:
                                   description: |-
@@ -3574,7 +3763,8 @@ spec:
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds extra command options if any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
                                   description: |-
@@ -3600,7 +3790,9 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
                               properties:
                                 datasetName:
                                   description: |-
@@ -3608,7 +3800,8 @@ spec:
                                     should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
@@ -3665,7 +3858,8 @@ spec:
                                   description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
@@ -3725,10 +3919,12 @@ spec:
                                 More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
                                   description: |-
@@ -3768,7 +3964,8 @@ spec:
                                     Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: |-
@@ -3838,7 +4035,9 @@ spec:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
                               properties:
                                 fsType:
                                   description: |-
@@ -3847,13 +4046,15 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
                                   description: |-
@@ -3867,13 +4068,15 @@ spec:
                                     the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
                                   description: |-
@@ -3888,10 +4091,12 @@ spec:
                                 sources:
                                   description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected along with other supported volume types
+                                    description: Projection that may be projected
+                                      along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: configMap information about the configMap data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
                                             description: |-
@@ -3903,7 +4108,8 @@ spec:
                                               the volume setup will error unless it is marked optional. Paths must be
                                               relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a path within a volume.
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
                                                   description: key is the key to project.
@@ -3936,26 +4142,38 @@ spec:
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about the downwardAPI data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume file
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field to select in the specified API version.
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
@@ -3972,7 +4190,13 @@ spec:
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
                                                   description: |-
@@ -3980,17 +4204,22 @@ spec:
                                                     (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name: required for volumes, optional for env vars'
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource to select'
+                                                      description: 'Required: resource
+                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -4002,7 +4231,8 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the secret data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
                                             description: |-
@@ -4014,7 +4244,8 @@ spec:
                                               the volume setup will error unless it is marked optional. Paths must be
                                               relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a path within a volume.
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
                                                   description: key is the key to project.
@@ -4047,12 +4278,14 @@ spec:
                                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
                                           optional:
-                                            description: optional field specify whether the Secret or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
                                             description: |-
@@ -4083,7 +4316,8 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 group:
                                   description: |-
@@ -4112,7 +4346,8 @@ spec:
                                     Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
@@ -4185,7 +4420,8 @@ spec:
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
                                   description: |-
@@ -4195,10 +4431,12 @@ spec:
                                     Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
                                   description: |-
@@ -4218,7 +4456,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
                                   description: |-
@@ -4226,10 +4465,12 @@ spec:
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
                                   description: |-
@@ -4267,7 +4508,8 @@ spec:
                                     the volume setup will error unless it is marked optional. Paths must be
                                     relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within a volume.
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
                                         description: key is the key to project.
@@ -4295,7 +4537,8 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
                                   description: |-
@@ -4304,7 +4547,8 @@ spec:
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
                                   description: |-
@@ -4345,7 +4589,8 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
                                   description: |-
@@ -4354,13 +4599,17 @@ spec:
                                     Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4404,10 +4653,12 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
+                                  description: Kind is the type of resource being
+                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
+                                  description: Name is the name of resource being
+                                    referenced
                                   type: string
                               required:
                               - kind
@@ -4441,10 +4692,12 @@ spec:
                                     For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
+                                  description: Kind is the type of resource being
+                                    referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
+                                  description: Name is the name of resource being
+                                    referenced
                                   type: string
                               required:
                               - kind
@@ -4485,17 +4738,20 @@ spec:
                                   type: object
                               type: object
                             selector:
-                              description: selector is a label query over volumes to consider for binding.
+                              description: selector is a label query over volumes
+                                to consider for binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -4537,14 +4793,16 @@ spec:
                                 Value of Filesystem is implied when not included in claim spec.
                               type: string
                             volumeName:
-                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
                               type: string
                           type: object
                       type: object
                     type: array
                   volumeMounts:
                     items:
-                      description: VolumeMount describes a mounting of a Volume within a container.
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
                       properties:
                         mountPath:
                           description: |-
@@ -4585,7 +4843,8 @@ spec:
                     type: array
                   volumes:
                     items:
-                      description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
                           description: |-
@@ -4622,16 +4881,20 @@ spec:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
                               type: string
                             diskName:
-                              description: diskName is the Name of the data disk in the blob storage
+                              description: diskName is the Name of the data disk in
+                                the blob storage
                               type: string
                             diskURI:
-                              description: diskURI is the URI of data disk in the blob storage
+                              description: diskURI is the URI of data disk in the
+                                blob storage
                               type: string
                             fsType:
                               description: |-
@@ -4640,7 +4903,11 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             kind:
-                              description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
                               type: string
                             readOnly:
                               description: |-
@@ -4652,7 +4919,8 @@ spec:
                           - diskURI
                           type: object
                         azureFile:
-                          description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
                               description: |-
@@ -4660,7 +4928,8 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
                               type: string
                             shareName:
                               description: shareName is the azure share Name
@@ -4670,7 +4939,8 @@ spec:
                           - shareName
                           type: object
                         cephfs:
-                          description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
                           properties:
                             monitors:
                               description: |-
@@ -4680,7 +4950,8 @@ spec:
                                 type: string
                               type: array
                             path:
-                              description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
                               description: |-
@@ -4752,7 +5023,8 @@ spec:
                           - volumeID
                           type: object
                         configMap:
-                          description: configMap represents a configMap that should populate this volume
+                          description: configMap represents a configMap that should
+                            populate this volume
                           properties:
                             defaultMode:
                               description: |-
@@ -4775,7 +5047,8 @@ spec:
                                 the volume setup will error unless it is marked optional. Paths must be
                                 relative and may not contain the '..' path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a volume.
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
                                     description: key is the key to project.
@@ -4808,12 +5081,15 @@ spec:
                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             optional:
-                              description: optional specify whether the ConfigMap or its keys must be defined
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         csi:
-                          description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
                           properties:
                             driver:
                               description: |-
@@ -4857,7 +5133,8 @@ spec:
                           - driver
                           type: object
                         downwardAPI:
-                          description: downwardAPI represents downward API about the pod that should populate this volume
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
                           properties:
                             defaultMode:
                               description: |-
@@ -4872,18 +5149,24 @@ spec:
                               format: int32
                               type: integer
                             items:
-                              description: Items is a list of downward API volume file
+                              description: Items is a list of downward API volume
+                                file
                               items:
-                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
-                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in the specified API version.
+                                        description: Path of the field to select in
+                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
@@ -4900,7 +5183,11 @@ spec:
                                     format: int32
                                     type: integer
                                   path:
-                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
                                     type: string
                                   resourceFieldRef:
                                     description: |-
@@ -4908,13 +5195,15 @@ spec:
                                       (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for volumes, optional for env vars'
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
@@ -5043,10 +5332,12 @@ spec:
                                             For any other third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                       required:
                                       - kind
@@ -5080,10 +5371,12 @@ spec:
                                             For any other third-party types, APIGroup is required.
                                           type: string
                                         kind:
-                                          description: Kind is the type of resource being referenced
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
-                                          description: Name is the name of resource being referenced
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                       required:
                                       - kind
@@ -5124,17 +5417,21 @@ spec:
                                           type: object
                                       type: object
                                     selector:
-                                      description: selector is a label query over volumes to consider for binding.
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
                                             description: |-
                                               A label selector requirement is a selector that contains values, a key, and an operator that
                                               relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
                                                 description: |-
@@ -5176,7 +5473,8 @@ spec:
                                         Value of Filesystem is implied when not included in claim spec.
                                       type: string
                                     volumeName:
-                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -5184,7 +5482,9 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
                           properties:
                             fsType:
                               description: |-
@@ -5202,7 +5502,8 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             targetWWNs:
-                              description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
                               items:
                                 type: string
                               type: array
@@ -5220,7 +5521,8 @@ spec:
                             provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: driver is the name of the driver to use for this volume.
+                              description: driver is the name of the driver to use
+                                for this volume.
                               type: string
                             fsType:
                               description: |-
@@ -5231,7 +5533,8 @@ spec:
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'options is Optional: this field holds extra command options if any.'
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
                               type: object
                             readOnly:
                               description: |-
@@ -5257,7 +5560,9 @@ spec:
                           - driver
                           type: object
                         flocker:
-                          description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
                           properties:
                             datasetName:
                               description: |-
@@ -5265,7 +5570,8 @@ spec:
                                 should be considered as deprecated
                               type: string
                             datasetUUID:
-                              description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
@@ -5322,7 +5628,8 @@ spec:
                               description: repository is the URL
                               type: string
                             revision:
-                              description: revision is the commit hash for the specified revision.
+                              description: revision is the commit hash for the specified
+                                revision.
                               type: string
                           required:
                           - repository
@@ -5382,10 +5689,12 @@ spec:
                             More info: https://examples.k8s.io/volumes/iscsi/README.md
                           properties:
                             chapAuthDiscovery:
-                              description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
                               description: |-
@@ -5425,7 +5734,8 @@ spec:
                                 Defaults to false.
                               type: boolean
                             secretRef:
-                              description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
                               properties:
                                 name:
                                   description: |-
@@ -5495,7 +5805,9 @@ spec:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
                           properties:
                             fsType:
                               description: |-
@@ -5504,13 +5816,15 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             pdID:
-                              description: pdID is the ID that identifies Photon Controller persistent disk
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
                               description: |-
@@ -5524,13 +5838,15 @@ spec:
                                 the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: volumeID uniquely identifies a Portworx volume
+                              description: volumeID uniquely identifies a Portworx
+                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: projected items for all in one resources secrets, configmaps, and downward API
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
                           properties:
                             defaultMode:
                               description: |-
@@ -5545,10 +5861,12 @@ spec:
                             sources:
                               description: sources is the list of volume projections
                               items:
-                                description: Projection that may be projected along with other supported volume types
+                                description: Projection that may be projected along
+                                  with other supported volume types
                                 properties:
                                   configMap:
-                                    description: configMap information about the configMap data to project
+                                    description: configMap information about the configMap
+                                      data to project
                                     properties:
                                       items:
                                         description: |-
@@ -5560,7 +5878,8 @@ spec:
                                           the volume setup will error unless it is marked optional. Paths must be
                                           relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: key is the key to project.
@@ -5593,26 +5912,36 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
-                                        description: optional specify whether the ConfigMap or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   downwardAPI:
-                                    description: downwardAPI information about the downwardAPI data to project
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
                                     properties:
                                       items:
-                                        description: Items is a list of DownwardAPIVolume file
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
@@ -5629,7 +5958,12 @@ spec:
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
                                               description: |-
@@ -5637,17 +5971,22 @@ spec:
                                                 (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -5659,7 +5998,8 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: secret information about the secret data to project
+                                    description: secret information about the secret
+                                      data to project
                                     properties:
                                       items:
                                         description: |-
@@ -5671,7 +6011,8 @@ spec:
                                           the volume setup will error unless it is marked optional. Paths must be
                                           relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
                                               description: key is the key to project.
@@ -5704,12 +6045,14 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                         type: string
                                       optional:
-                                        description: optional field specify whether the Secret or its key must be defined
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   serviceAccountToken:
-                                    description: serviceAccountToken is information about the serviceAccountToken data to project
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
                                     properties:
                                       audience:
                                         description: |-
@@ -5740,7 +6083,8 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
                           properties:
                             group:
                               description: |-
@@ -5769,7 +6113,8 @@ spec:
                                 Defaults to serivceaccount user
                               type: string
                             volume:
-                              description: volume is a string that references an already created Quobyte volume by name.
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
@@ -5842,7 +6187,8 @@ spec:
                           - monitors
                           type: object
                         scaleIO:
-                          description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
                               description: |-
@@ -5852,10 +6198,12 @@ spec:
                                 Default is "xfs".
                               type: string
                             gateway:
-                              description: gateway is the host address of the ScaleIO API Gateway.
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
                               type: string
                             protectionDomain:
-                              description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
                               type: string
                             readOnly:
                               description: |-
@@ -5875,7 +6223,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             sslEnabled:
-                              description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
                               type: boolean
                             storageMode:
                               description: |-
@@ -5883,10 +6232,12 @@ spec:
                                 Default is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
                               type: string
                             system:
-                              description: system is the name of the storage system as configured in ScaleIO.
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
                               type: string
                             volumeName:
                               description: |-
@@ -5924,7 +6275,8 @@ spec:
                                 the volume setup will error unless it is marked optional. Paths must be
                                 relative and may not contain the '..' path or start with '..'.
                               items:
-                                description: Maps a string key to a path within a volume.
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
                                     description: key is the key to project.
@@ -5952,7 +6304,8 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: optional field specify whether the Secret or its keys must be defined
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
                               description: |-
@@ -5961,7 +6314,8 @@ spec:
                               type: string
                           type: object
                         storageos:
-                          description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
                               description: |-
@@ -6002,7 +6356,8 @@ spec:
                               type: string
                           type: object
                         vsphereVolume:
-                          description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
                           properties:
                             fsType:
                               description: |-
@@ -6011,13 +6366,16 @@ spec:
                                 Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                               type: string
                             storagePolicyID:
-                              description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
                               type: string
                             volumePath:
-                              description: volumePath is the path that identifies vSphere volume vmdk
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -6389,7 +6747,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v33
+        image: tetrate/kubegres:v1.16.0-tetrate-v34
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| CRITICAL | CVE-2026-33815 | github.com/jackc/pgx/v5/pgproto3 | Bump pgx/v5 from v5.7.5 to v5.9.1 |

## Changes

- Bumped `github.com/jackc/pgx/v5` from `v5.7.5` to `v5.9.1` to fix CVE-2026-33815 (GHSA-xgrm-4fwx-7qm8), a critical memory-safety vulnerability in `pgproto3`. The fix requires pgx >= 5.9.0.
- Updated `config/manager/kustomization.yaml` and `kubegres.yaml` to reference the new release tag `v1.16.0-tetrate-v34`.

## Background

CVE-2026-33815 (CVSS 9.8 CRITICAL): pgx prior to v5.9.0 contains a memory-safety vulnerability in `pgproto3`. This affects kubegres tags `v1.16.0-tetrate-v32` and `v1.16.0-tetrate-v33`, both of which use pgx v5.7.5.

Related to tetrateio/tetrate#29362
Related to tetrateio/tetrate#29363
Related to tetrateio/tetrate#29364
Related to tetrateio/tetrate#29418