### PR TITLE
cves: bump github.com/jackc/pgx/v5 to v5.9.2, release `v1.16.0-tetrate-v35`

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v34
+  newTag: v1.16.0-tetrate-v35

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v34
+        image: tetrate/kubegres:v1.16.0-tetrate-v35
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| LOW | GHSA-j88v-2chj-qfwx | github.com/jackc/pgx/v5 | bumped v5.9.1 → v5.9.2 |

Bumps `github.com/jackc/pgx/v5` from v5.9.1 to v5.9.2. Also updates `config/manager/kustomization.yaml` and `kubegres.yaml` to release tag `v1.16.0-tetrate-v35`.

pgx v5.9.2 fixes SQL injection via placeholder confusion with dollar quoted string literals (GHSA-j88v-2chj-qfwx).

Related to tetrateio/tetrate#29712
Related to tetrateio/tetrate#29714
Related to tetrateio/tetrate#29715
Related to tetrateio/tetrate#29716