### PR TITLE
cves: bump go to 1.26.3, release `v1.16.0-tetrate-v36`

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v35
+  newTag: v1.16.0-tetrate-v36

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v35
+        image: tetrate/kubegres:v1.16.0-tetrate-v36
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

Bump Go version from 1.25.9 to 1.26.3 and prepare release `v1.16.0-tetrate-v36`.

## Changes

- Updated `go` directive to `1.26.3` in `go.mod`
- Ran `go mod tidy`
- Updated `config/manager/kustomization.yaml` and `kubegres.yaml` via `make deploy` with `IMG=tetrate/kubegres:v1.16.0-tetrate-v36`


Generated by Claude from local run, so this one is signed by me, no issues this time