### PR TITLE
cves: bump go to 1.25.10, release `v1.16.0-tetrate-v36`

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v35
+  newTag: v1.16.0-tetrate-v36

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v35
+        image: tetrate/kubegres:v1.16.0-tetrate-v36
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| HIGH | CVE-2026-39825 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-39836 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-42499 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-33811 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-39826 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-39820 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-33814 | stdlib | Bump Go 1.25.9 → 1.25.10 |
| HIGH | CVE-2026-39823 | stdlib | Bump Go 1.25.9 → 1.25.10 |

## Changes

- Bumped Go toolchain from `1.25.9` to `1.25.10` in `go.mod`
- Updated `config/manager/kustomization.yaml` to reference new tag `v1.16.0-tetrate-v36`
- Regenerated `kubegres.yaml` with new image tag

## Related monorepo issues

Related to tetrateio/tetrate#30114
Related to tetrateio/tetrate#30115
Related to tetrateio/tetrate#30116
Related to tetrateio/tetrate#30117
Related to tetrateio/tetrate#30118
Related to tetrateio/tetrate#30119
Related to tetrateio/tetrate#30120
Related to tetrateio/tetrate#30121
Related to tetrateio/tetrate#30122
Related to tetrateio/tetrate#30123
Related to tetrateio/tetrate#30126
Related to tetrateio/tetrate#30127
Related to tetrateio/tetrate#30128
Related to tetrateio/tetrate#30129
Related to tetrateio/tetrate#30130
Related to tetrateio/tetrate#30131
Related to tetrateio/tetrate#30132
Related to tetrateio/tetrate#30133
Related to tetrateio/tetrate#30134
Related to tetrateio/tetrate#30135
Related to tetrateio/tetrate#30136
Related to tetrateio/tetrate#30137
Related to tetrateio/tetrate#30138
Related to tetrateio/tetrate#30139
Related to tetrateio/tetrate#30142
Related to tetrateio/tetrate#30143
Related to tetrateio/tetrate#30144
Related to tetrateio/tetrate#30145
Related to tetrateio/tetrate#30146
Related to tetrateio/tetrate#30147
Related to tetrateio/tetrate#30148
Related to tetrateio/tetrate#30149