### PR TITLE
cves: bump go to 1.26.4, release `v1.16.0-tetrate-v38`

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v37
+  newTag: v1.16.0-tetrate-v38

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v37
+        image: tetrate/kubegres:v1.16.0-tetrate-v38
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| UNKNOWN | CVE-2026-42504 | stdlib | bumped Go 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-27145 | stdlib | bumped Go 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-42507 | stdlib | bumped Go 1.26.3 → 1.26.4 |

Related to tetrateio/tetrate#30698
Related to tetrateio/tetrate#30699
Related to tetrateio/tetrate#30700
Related to tetrateio/tetrate#30701
Related to tetrateio/tetrate#30702
Related to tetrateio/tetrate#30703
Related to tetrateio/tetrate#30704
Related to tetrateio/tetrate#30705
Related to tetrateio/tetrate#30706
Related to tetrateio/tetrate#30707
Related to tetrateio/tetrate#30708
Related to tetrateio/tetrate#30709