### PR TITLE
cves: release `v1.16.0-tetrate-v39` for CVE-2026-39821 (x/net)

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v38
+  newTag: v1.16.0-tetrate-v39

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v38
+        image: tetrate/kubegres:v1.16.0-tetrate-v39
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

Cuts release `v1.16.0-tetrate-v39`. The CVE fix (`golang.org/x/net` → `v0.56.0` for **CVE-2026-39821**) was already merged via #88, which only touched `go.mod`/`go.sum`. This PR runs `make deploy` to bump the in-repo manifests (`config/manager/kustomization.yaml`, `kubegres.yaml`) to `v1.16.0-tetrate-v39` so the `Publish Release` workflow's `check-kubegres-yaml` gate passes and the `v39` image can be cut.

## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| HIGH | CVE-2026-39821 | golang.org/x/net | bumped v0.53.0 → v0.56.0 (merged in #88) |

## Changes

- `config/manager/kustomization.yaml`: `newTag` v1.16.0-tetrate-v38 → v1.16.0-tetrate-v39
- `kubegres.yaml`: controller image v1.16.0-tetrate-v38 → v1.16.0-tetrate-v39

After merge, the `Publish Release` workflow will be dispatched to build and push `tetrate/kubegres:v1.16.0-tetrate-v39`.
