### PR TITLE
cves: bump go to 1.26.5

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tetrate/kubegres
-  newTag: v1.16.0-tetrate-v39
+  newTag: v1.16.0-tetrate-v40

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module reactive-tech.io/kubegres
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -6389,7 +6389,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: tetrate/kubegres:v1.16.0-tetrate-v39
+        image: tetrate/kubegres:v1.16.0-tetrate-v40
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| HIGH | CVE-2026-42505 | stdlib | Go 1.26.5 |
| HIGH | CVE-2026-39822 | stdlib | Go 1.26.5 |

## Changes

- Bumped Go from 1.26.4 to 1.26.5 in `go.mod`
- Ran `go mod tidy`
- Updated `config/manager/kustomization.yaml` and `kubegres.yaml` via `make deploy` equivalent for tag `v1.16.0-tetrate-v40`

## Expected new tag

`v1.16.0-tetrate-v40`

Related to tetrateio/tetrate#31967
Related to tetrateio/tetrate#31968
Related to tetrateio/tetrate#31970
Related to tetrateio/tetrate#31971
Related to tetrateio/tetrate#31973
Related to tetrateio/tetrate#31974